### PR TITLE
Fix to get previous behaviour of '()' operator (indexing without casting).

### DIFF
--- a/activations.hpp
+++ b/activations.hpp
@@ -193,7 +193,7 @@ void Thresholding_Batch(hls::stream<TI> &in,
     {
 #pragma HLS UNROLL
       auto const act = TSrcI()(inElem);
-      outElem(pe,0) = activation.activate(nf, pe, act(pe,0));
+      outElem(pe,0,1) = activation.activate(nf, pe, act(pe,0));
     }
     out.write(outElem);
     if (++nf == NF)


### PR DESCRIPTION
Add flag parameter to choose the '()' operator overload that has the previous behaviour