### PR TITLE
New activation with a parameter per channel

### DIFF
--- a/activations.hpp
+++ b/activations.hpp
@@ -162,7 +162,7 @@ template<unsigned NF, unsigned PE,
    typename TI, typename TP, typename TR, typename Fxn = std::multiplies<TR>>
 class ChannelWiseOperation {
 public:
-  TP parameter[PE][NF];
+  TP parameters[PE][NF];
 public:
   TI init(unsigned const  nf, unsigned const  pe) const {
 #pragma HLS inline
@@ -171,7 +171,7 @@ public:
 public:
   TR activate(unsigned const  nf, unsigned const  pe,  TI const &in) const {
 #pragma HLS inline
-    TR result = Fxn()(parameter[pe][nf], in);
+    TR result = Fxn()(parameters[pe][nf], in);
     return result;
   }
 };

--- a/activations.hpp
+++ b/activations.hpp
@@ -145,6 +145,36 @@ public:
   }
 };
 
+
+/**
+ * Use a simple per-row function.
+ *
+ * The thresholds are taken from an array indexed by output row.
+ * It is currently public to allow direct initialization and
+ * to make its name accessible for top-level HLS pragmas.
+ *
+ * The default comparison returns true if the threshold value defined for
+ * the indexed row is smaller than the passed accumulator value.
+ */
+
+template<unsigned NF, unsigned PE,
+   typename TI, typename TP, typename TR, typename Fxn = std::multiplies<TR>>
+class ChannelWiseOperation {
+public:
+  TP parameter[PE][NF];
+public:
+  TI init(unsigned const  nf, unsigned const  pe) const {
+#pragma HLS inline
+    return  TI(0);
+  }
+public:
+  TR activate(unsigned const  nf, unsigned const  pe,  TI const &in) const {
+#pragma HLS inline
+    TR result = Fxn()(parameter[pe][nf], in);
+    return result;
+  }
+};
+
 /**
  * \brief Thresholding function for multiple images
  *
@@ -186,6 +216,8 @@ void Thresholding_Batch(hls::stream<TI> &in,
   // of smaller nested loops) to get the pipelinening the way we want
   for (unsigned i = 0; i < reps * ImgDim * ImgDim * NF; i++)
   {
+    #pragma HLS PIPELINE II=1
+
     TI inElem;
     inElem = in.read();
     auto outElem = TDstI().template operator()<TO>();

--- a/activations.hpp
+++ b/activations.hpp
@@ -147,14 +147,15 @@ public:
 
 
 /**
- * Use a simple per-row function.
+ * Use a simple function with per-row parameters.
  *
- * The thresholds are taken from an array indexed by output row.
+ * The parameters are taken from an array indexed by output row.
  * It is currently public to allow direct initialization and
  * to make its name accessible for top-level HLS pragmas.
- *
- * The default comparison returns true if the threshold value defined for
- * the indexed row is smaller than the passed accumulator value.
+ * 
+ * TI    DataType of input layer values
+ * TP    DataType of parameters
+ * TR    DataType of return values
  */
 
 template<unsigned NF, unsigned PE,

--- a/activations.hpp
+++ b/activations.hpp
@@ -147,7 +147,7 @@ public:
 
 
 /**
- * Use a simple function with per-row parameters.
+ * Use a simple activation function with per-row parameters.
  *
  * The parameters are taken from an array indexed by output row.
  * It is currently public to allow direct initialization and

--- a/tb/channelwise_op_tb.cpp
+++ b/tb/channelwise_op_tb.cpp
@@ -85,7 +85,7 @@ int main()
                         if (expected_out != produced_out){
                             std::cout << "ERROR: In round"<<round_idx<<", Expected["<<oy <<"]["<<ox<<"]["<<channel<<"]=" 
                             << expected_out << " actual " <<  produced_out <<
-                            " | input value:"<<IMAGE[n_image][ox][oy][channel] <<
+                            " | input value:"<<IMAGE[round_idx][n_image][ox][oy][channel] <<
                             " | Params - >  bip: "<<bipolar_init[pe_idx][f_idx]<< 
                             " | add: "<<add_init[pe_idx][f_idx]<< 
                             " | mul: "<<mult_init[pe_idx][f_idx]<< 

--- a/tb/channelwise_op_tb.cpp
+++ b/tb/channelwise_op_tb.cpp
@@ -1,3 +1,44 @@
+/******************************************************************************
+ *  Copyright (c) 2019, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ *
+ *  Authors: Giulio Gambardella <giuliog@xilinx.com>
+ *           Tobias Alonso <tobiasa@xilinx.com>
+ *
+ *  \file channelwise_op_tb.cpp
+ *
+ *  Testbench for the ChannelWiseOperation activation
+ *
+ *****************************************************************************/
 
 #include <iostream>
 #include <cmath>

--- a/tb/channelwise_op_tb.cpp
+++ b/tb/channelwise_op_tb.cpp
@@ -1,0 +1,121 @@
+
+#include <iostream>
+#include <cmath>
+#include <cstring>
+#include <hls_stream.h>
+#include <cstdlib>
+#define AP_INT_MAX_W 16384
+#include "ap_int.h"
+#include "weights.hpp"
+#include "bnn-library.h"
+#include "activations.hpp"
+#include "interpret.hpp"
+using namespace hls;
+using namespace std;
+  
+#include "channelwise_op_top.h"  
+
+#define MAX_IMAGES 2
+#define ROUNDS 2 // ROUNDS >1 to get cosim to measure II
+
+int main()
+{   
+
+    // input and output of verification function
+    int IMAGE[ROUNDS][MAX_IMAGES][IFMDim][IFMDim][IFM_Channels];
+
+    // input and output of DUT
+    stream<ap_uint<IFM_Channels*INPUT_BITS> > input_stream[ROUNDS];
+    stream<ap_uint<IFM_Channels*OUTPUT_BITS> > output_stream[ROUNDS];
+
+    // generate image and load input stream 
+    unsigned int counter = 0;
+    for(unsigned int round_idx = 0; round_idx < ROUNDS; round_idx++) {
+        for (unsigned int n_image = 0; n_image < MAX_IMAGES; n_image++) {
+            for (unsigned int oy = 0; oy < IFMDim; oy++) {
+                for (unsigned int ox = 0; ox < IFMDim; ox++) {
+                    IN_T<INPUT_BITS*IFM_Channels> input_channel = 0;
+                    for(unsigned int channel = 0; channel < IFM_Channels; channel++)
+                    {   
+                        // generate new value casted to the input type
+                        IN_T<INPUT_BITS> input = (IN_T<INPUT_BITS>)(counter);
+
+                        // store value in image for verification function
+                        IMAGE[round_idx][n_image][ox][oy][channel]= input;
+
+                        // insert on most significant bits of pixel buffer
+                        input_channel = input_channel >> INPUT_BITS;
+                        input_channel(IFM_Channels*INPUT_BITS-1,(IFM_Channels-1)*INPUT_BITS)=input;
+
+                        counter++;
+                    }
+                    input_stream[round_idx].write(input_channel);
+                }
+            }
+        }
+    }
+
+    // call DUT
+    for (int i = 0; i < ROUNDS; ++i)
+    {
+        Testbench_channelwise_op(input_stream[i], output_stream[i], MAX_IMAGES);
+    }
+    
+
+    // verification function
+    int err_counter = 0, err_perimage=0;
+    OUT_T<OUTPUT_BITS> produced_out;
+    for(unsigned int round_idx = 0; round_idx < ROUNDS; round_idx++) {
+        for (unsigned int n_image = 0; n_image < MAX_IMAGES; n_image++) {
+            for (unsigned int oy = 0; oy < OFMDim; oy++) {
+                for (unsigned int ox = 0; ox < OFMDim; ox++) {
+                    OUT_T<OFM_Channels*OUTPUT_BITS> outElem = output_stream[round_idx].read();
+
+                    for(unsigned int channel = 0; channel < OFM_Channels; channel++){
+                        int f_idx = int(channel/PE);
+                        int pe_idx = channel%PE;
+
+                        int expected_out  = IMAGE[round_idx][n_image][ox][oy][channel];
+                        expected_out  = bipolar_init[pe_idx][f_idx]? expected_out:-expected_out;
+                        expected_out += add_init[pe_idx][f_idx];
+                        expected_out *= mult_init[pe_idx][f_idx];
+
+                        produced_out = outElem((channel + 1)*OUTPUT_BITS-1,channel*OUTPUT_BITS);
+
+                        if (expected_out != produced_out){
+                            std::cout << "ERROR: In round"<<round_idx<<", Expected["<<oy <<"]["<<ox<<"]["<<channel<<"]=" 
+                            << expected_out << " actual " <<  produced_out <<
+                            " | input value:"<<IMAGE[n_image][ox][oy][channel] <<
+                            " | Params - >  bip: "<<bipolar_init[pe_idx][f_idx]<< 
+                            " | add: "<<add_init[pe_idx][f_idx]<< 
+                            " | mul: "<<mult_init[pe_idx][f_idx]<< 
+                            std::endl;
+                            err_counter ++;
+                            err_perimage++;
+                        }
+                    }
+                    
+                }
+            }
+
+            if(err_perimage == 0){
+                std::cout<<"Round "<<round_idx << ", Image # " << n_image << " passed the testing."<< std::endl;
+            }
+            else{
+                std::cout << "Round "<<round_idx << ", Image # " << n_image << " failed the testing."<<
+                " Errors:"<<err_perimage<<"/"<<OFMDim*OFMDim*OFM_Channels << std::endl;
+                err_perimage=0;
+            }
+        }
+    }
+
+    if(err_counter == 0){
+        return 0;
+    }
+    else{
+        return 1;
+    }
+
+}
+
+

--- a/tb/channelwise_op_top.cpp
+++ b/tb/channelwise_op_top.cpp
@@ -1,3 +1,44 @@
+/******************************************************************************
+ *  Copyright (c) 2019, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ *
+ *  Authors: Tobias Alonso <tobiasa@xilinx.com>
+ *
+ *  \file channelwise_op_top.cpp
+ *  
+ *  HLS Top function with three ChannelWiseOperation activation layers for unit 
+ *  testing
+ *  
+ *****************************************************************************/
 
 #include "channelwise_op_top.h"
 

--- a/tb/channelwise_op_top.cpp
+++ b/tb/channelwise_op_top.cpp
@@ -1,0 +1,52 @@
+
+#include "channelwise_op_top.h"
+
+// Implements:
+// in -> [width adapt] -> [bipolar mult] -> [add]  -> [mult] -> [width adapt] -> out
+void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in, 
+                    stream<ap_uint<OFM_Channels*OUTPUT_BITS> > & out, unsigned int numReps){
+    #pragma HLS DATAFLOW
+    
+    
+    // [width adapt] 
+    stream<ap_uint<PE*INPUT_BITS>>  wa_in;
+    StreamingDataWidthConverter_Batch<IFM_Channels*INPUT_BITS, PE*INPUT_BITS, IFMDim*IFMDim>(
+        in, wa_in, numReps);
+
+
+    // [bipolar mult]
+    ChannelWiseOperation<NF, PE,ap_uint<INPUT_BITS>, BIPO_OUT_TYPE, 
+                BIPO_PARAM_TYPE, per_channel_neg<BIPO_OUT_TYPE> > bipolar_params= 
+                                        {.parameter = BIPOLAR_INIT};
+    
+    stream<ap_uint<PE*BIPO_OUT_BITS>>  bipolar_out;
+    Thresholding_Batch< IFMDim, IFM_Channels, PE,
+        Slice< ap_uint<INPUT_BITS> >, Slice<BIPO_OUT_TYPE> >
+        (wa_in, bipolar_out, bipolar_params, numReps);
+
+
+    // [add] 
+    ChannelWiseOperation<NF, PE,BIPO_OUT_TYPE, ADD_OUT_TYPE, 
+                ADD_PARAM_TYPE, std::plus<ADD_OUT_TYPE> > add_params = 
+                                                    {.parameter = ADD_INIT};
+    
+    stream<ap_uint<PE*ADD_OUT_BITS>>  add_out;
+    Thresholding_Batch< IFMDim, IFM_Channels, PE,
+        Slice<BIPO_OUT_TYPE>, Slice<ADD_OUT_TYPE> >
+        (bipolar_out, add_out, add_params, numReps);
+
+
+    // [mult] 
+    ChannelWiseOperation<NF, PE,ADD_OUT_TYPE, MULT_OUT_TYPE, 
+                MULT_PARAM_TYPE, std::multiplies<MULT_OUT_TYPE> > mult_params= 
+                                                        {.parameter = MULT_INIT};
+    
+    stream<ap_uint<PE*MULT_OUT_BITS>>  mul_out;
+    Thresholding_Batch< IFMDim, IFM_Channels, PE,
+        Slice<ADD_OUT_TYPE>, Slice<MULT_OUT_TYPE> >
+        (add_out, mul_out, mult_params, numReps);
+
+    // [width adapt]
+    StreamingDataWidthConverter_Batch<PE*MULT_OUT_BITS, OFM_Channels*MULT_OUT_BITS, 
+        IFMDim*IFMDim*NF >(mul_out, out, numReps);
+}

--- a/tb/channelwise_op_top.cpp
+++ b/tb/channelwise_op_top.cpp
@@ -15,9 +15,8 @@ void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in,
 
 
     // [bipolar mult]
-    ChannelWiseOperation<NF, PE,ap_uint<INPUT_BITS>, BIPO_OUT_TYPE, 
-                BIPO_PARAM_TYPE, per_channel_neg<BIPO_OUT_TYPE> > bipolar_params= 
-                                        {.parameter = BIPOLAR_INIT};
+    ChannelWiseOperation<FOLD, PE,ap_uint<INPUT_BITS>, BIPO_PARAM_TYPE, BIPO_OUT_TYPE, 
+            per_channel_neg<BIPO_OUT_TYPE> > bipolar_params= {.parameters = BIPOLAR_INIT};
     
     stream<ap_uint<PE*BIPO_OUT_BITS>>  bipolar_out;
     Thresholding_Batch< IFMDim, IFM_Channels, PE,
@@ -26,9 +25,8 @@ void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in,
 
 
     // [add] 
-    ChannelWiseOperation<NF, PE,BIPO_OUT_TYPE, ADD_OUT_TYPE, 
-                ADD_PARAM_TYPE, std::plus<ADD_OUT_TYPE> > add_params = 
-                                                    {.parameter = ADD_INIT};
+    ChannelWiseOperation<FOLD, PE,BIPO_OUT_TYPE, ADD_PARAM_TYPE, ADD_OUT_TYPE, 
+            std::plus<ADD_OUT_TYPE> > add_params = {.parameters = ADD_INIT};
     
     stream<ap_uint<PE*ADD_OUT_BITS>>  add_out;
     Thresholding_Batch< IFMDim, IFM_Channels, PE,
@@ -37,9 +35,8 @@ void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in,
 
 
     // [mult] 
-    ChannelWiseOperation<NF, PE,ADD_OUT_TYPE, MULT_OUT_TYPE, 
-                MULT_PARAM_TYPE, std::multiplies<MULT_OUT_TYPE> > mult_params= 
-                                                        {.parameter = MULT_INIT};
+    ChannelWiseOperation<FOLD, PE,ADD_OUT_TYPE, MULT_PARAM_TYPE, MULT_OUT_TYPE, 
+            std::multiplies<MULT_OUT_TYPE> > mult_params= {.parameters = MULT_INIT};
     
     stream<ap_uint<PE*MULT_OUT_BITS>>  mul_out;
     Thresholding_Batch< IFMDim, IFM_Channels, PE,
@@ -48,5 +45,5 @@ void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in,
 
     // [width adapt]
     StreamingDataWidthConverter_Batch<PE*MULT_OUT_BITS, OFM_Channels*MULT_OUT_BITS, 
-        IFMDim*IFMDim*NF >(mul_out, out, numReps);
+        IFMDim*IFMDim*FOLD >(mul_out, out, numReps);
 }

--- a/tb/channelwise_op_top.h
+++ b/tb/channelwise_op_top.h
@@ -1,3 +1,35 @@
+/******************************************************************************
+ *  Copyright (c) 2019, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <hls_stream.h>
 using namespace hls;
 #include "ap_int.h"

--- a/tb/channelwise_op_top.h
+++ b/tb/channelwise_op_top.h
@@ -34,14 +34,14 @@ using namespace hls;
 #define MULT_OUT_TYPE  ap_int<MULT_OUT_BITS>
 #define OUT_T ap_int
 
-#define NF (IFM_Channels/PE)
+#define FOLD (OFM_Channels/PE)
 
 
 
 
-const int bipolar_init[PE][NF] = BIPOLAR_INIT;
-const int add_init[PE][NF] = ADD_INIT;
-const int mult_init[PE][NF] = MULT_INIT;
+const int bipolar_init[PE][FOLD] = BIPOLAR_INIT;
+const int add_init[PE][FOLD] = ADD_INIT;
+const int mult_init[PE][FOLD] = MULT_INIT;
 
 template<typename T>
 struct per_channel_neg

--- a/tb/channelwise_op_top.h
+++ b/tb/channelwise_op_top.h
@@ -1,0 +1,57 @@
+#include <hls_stream.h>
+using namespace hls;
+#include "ap_int.h"
+#include "bnn-library.h"
+
+#include "activations.hpp"
+#include "weights.hpp"
+#include "interpret.hpp"
+
+
+#define PE 4
+#define IFM_Channels 8
+#define OFM_Channels IFM_Channels
+
+#define IFMDim 3
+#define OFMDim IFMDim
+
+#define BIPO_PARAM_TYPE ap_uint<1>
+#define ADD_PARAM_TYPE ap_int<3> 
+#define MULT_PARAM_TYPE ap_int<3>
+#define BIPOLAR_INIT {{1,1},{1,0},{0,1},{1,1}}
+#define ADD_INIT {{ 2, 1},{ 0,-1},{-1,-3},{ 1, 1}} 
+#define MULT_INIT {{ 3, 1}, { 2,-1}, {-1, 1}, { 1,-2}} 
+
+#define INPUT_BITS 4
+#define BIPO_OUT_BITS  (INPUT_BITS+1)
+#define ADD_OUT_BITS  (BIPO_OUT_BITS+1)
+#define MULT_OUT_BITS  (ADD_OUT_BITS+2)
+#define OUTPUT_BITS MULT_OUT_BITS
+
+#define IN_T ap_uint
+#define BIPO_OUT_TYPE  ap_int<BIPO_OUT_BITS>
+#define ADD_OUT_TYPE  ap_int<ADD_OUT_BITS>
+#define MULT_OUT_TYPE  ap_int<MULT_OUT_BITS>
+#define OUT_T ap_int
+
+#define NF (IFM_Channels/PE)
+
+
+
+
+const int bipolar_init[PE][NF] = BIPOLAR_INIT;
+const int add_init[PE][NF] = ADD_INIT;
+const int mult_init[PE][NF] = MULT_INIT;
+
+template<typename T>
+struct per_channel_neg
+{
+    constexpr T operator()(const ap_uint<1> &lhs, const T &rhs) const {
+        return lhs? static_cast<decltype(-rhs)>(rhs):-rhs;
+    }
+    
+};
+
+
+void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in, 
+                    stream<ap_uint<OFM_Channels*OUTPUT_BITS> > & out, unsigned int numReps);

--- a/tb/test_channelwise_op.tcl
+++ b/tb/test_channelwise_op.tcl
@@ -1,3 +1,44 @@
+##############################################################################
+ #  Copyright (c) 2019, Xilinx, Inc.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions are met:
+ #
+ #  1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ #  2.  Redistributions in binary form must reproduce the above copyright
+ #      notice, this list of conditions and the following disclaimer in the
+ #      documentation and/or other materials provided with the distribution.
+ #
+ #  3.  Neither the name of the copyright holder nor the names of its
+ #      contributors may be used to endorse or promote products derived from
+ #      this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ #  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ #  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ #  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ #  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ #  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+###############################################################################
+###############################################################################
+ #
+ #  Authors: Giulio Gambardella <giuliog@xilinx.com>
+ #           Tobias Alonso <tobiasa@xilinx.com>
+ #
+ # \file test_channelwise_op.tcl
+ #
+ # Tcl script for HLS csim, synthesis and cosim of the ChannelWiseOperation activation test
+ #
+###############################################################################
 
 open_project hls-syn-channelwise-op
 add_files channelwise_op_top.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 

--- a/tb/test_channelwise_op.tcl
+++ b/tb/test_channelwise_op.tcl
@@ -1,0 +1,12 @@
+
+open_project hls-syn-channelwise-op
+add_files channelwise_op_top.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+add_files -tb channelwise_op_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+set_top Testbench_channelwise_op
+open_solution sol1
+set_part {xczu3eg-sbva484-1-i}
+create_clock -period 5 -name default
+csim_design
+csynth_design
+cosim_design
+exit


### PR DESCRIPTION
This activation allows having different data types for the input, parameters and output.

Solves Issue #9. by using first the new `ChannelWiseOperation` activation and then the required activation 