### PR TITLE
Shorten swg kernel stride long pipe

### DIFF
--- a/slidingwindow.h
+++ b/slidingwindow.h
@@ -471,16 +471,9 @@ void ConvolutionInputGenerator_kernel_stride(
 	const unsigned int baseIter = (IFMDim * ConvKernelDim * multiplying_factor) + (OFMDim-1) * max_cycles+MAX(cycles_write_block,OFMDim);
 	const unsigned int initial_buffer_cycles = (IFMDim * ConvKernelDim * multiplying_factor) ;
 	unsigned int counter_internal_block = 0;
-	unsigned int current_block_write = 0;
-#pragma HLS DEPENDENCE variable=current_block_write intra false
-#pragma HLS DEPENDENCE variable=current_block_write inter false
-
 	unsigned int next_block_write = 0;
 	unsigned int current_line = 0;
-	unsigned int read_block = 0;
-#pragma HLS RESET variable=read_block
-#pragma HLS DEPENDENCE variable=read_block intra false
-#pragma HLS DEPENDENCE variable=read_block inter false
+
 	unsigned int inp = 0, ofm_y = 0, ofm_x = 0, k_y = 0, k_x = 0, current_k_y = 0, count_simd =0;
 #pragma HLS RESET variable=inp
 
@@ -489,6 +482,10 @@ void ConvolutionInputGenerator_kernel_stride(
 
 // #pragma HLS RESOURCE variable inputBuf core=RAM_2P_LUTRAM
 for (unsigned int count_image = 0; count_image < numReps; count_image++) {
+  unsigned int floor_block_read = 0, ceil_block_read = number_blocks;
+  unsigned int current_block_write = 0;
+  #pragma HLS DEPENDENCE variable=current_block_write intra false
+  unsigned int read_block = 0;
 		for (unsigned int i = 0; i < baseIter; i++) {
 	#pragma HLS PIPELINE II=1
 			if (inp < initial_buffer_cycles) // Initial buffer of PoolDim lines
@@ -512,7 +509,19 @@ for (unsigned int count_image = 0; count_image < numReps; count_image++) {
 			{
 				if (counter_internal_block < cycles_write_block-1 || read_block==IFMDim) // We are writing output, MMV IFMChan per cycle
 				{
-					unsigned int current_block_read = (ofm_y*Stride + k_y)%number_blocks;
+					//following code implements: current_block_read = (ofm_y*Stride + k_y)%number_blocks;
+          unsigned int current_block_read = (ofm_y*Stride + k_y);
+            //reminder computation
+            if (current_block_read >= ceil_block_read)
+            {
+              floor_block_read += number_blocks;
+              ceil_block_read += number_blocks;
+            }else if(current_block_read < floor_block_read){
+              ceil_block_read -= number_blocks;
+              floor_block_read -= number_blocks;
+            }
+            current_block_read -= floor_block_read;
+
 					unsigned int current_line_in_block = (ofm_x * Stride + k_x)*multiplying_factor + count_simd;
 					ap_uint<SIMD*Input_precision> outElem = inputBuf[current_block_read][(current_line_in_block)];
 					out.write(outElem);
@@ -553,7 +562,7 @@ for (unsigned int count_image = 0; count_image < numReps; count_image++) {
 						current_block_write++;
 						if (current_block_write == number_blocks)
 							current_block_write = 0;
-	#pragma HLS DEPENDENCE variable=current_block_write intra false
+#pragma HLS DEPENDENCE variable=current_block_write intra false
 					}
 				}
 				counter_internal_block++; // = (counter_internal_block +1) % max_cycles;
@@ -563,9 +572,7 @@ for (unsigned int count_image = 0; count_image < numReps; count_image++) {
 				}
 			}
 		} // End base_iter
-		current_block_write=0;
-		read_block=0;
-    }
+  }
 }
 
 
@@ -719,126 +726,134 @@ void ConvolutionInputGenerator_dws(
  */
 
 template<unsigned int ConvKernelDim, 
-		 unsigned int IFMChannels,
-		 unsigned int Input_precision,		
-		 unsigned int IFMDim, 
-		 unsigned int OFMDim,
-		 unsigned int SIMD,
-		 unsigned int Stride, 
-		 typename R>  
+         unsigned int IFMChannels,
+         unsigned int Input_precision,      
+         unsigned int IFMDim, 
+         unsigned int OFMDim,
+         unsigned int SIMD,
+         unsigned int Stride, 
+         typename R>  
 void ConvolutionInputGenerator_kernel_stride_dws(  
     stream<ap_uint<SIMD*Input_precision> > & in,
     stream<ap_uint<SIMD*Input_precision> > & out,
-	const unsigned int numReps,
-	R const &r) {
-	CASSERT_DATAFLOW(IFMChannels % SIMD == 0);
+    const unsigned int numReps,
+    R const &r) {
+    CASSERT_DATAFLOW(IFMChannels % SIMD == 0);
     CASSERT_DATAFLOW(ConvKernelDim % Stride != 0);
-	const unsigned int multiplying_factor = IFMChannels/SIMD;
-	const unsigned int number_blocks = ConvKernelDim + Stride ;
-	ap_uint<SIMD*Input_precision> inputBuf[number_blocks][IFMDim * multiplying_factor];
+    const unsigned int multiplying_factor = IFMChannels/SIMD;
+    const unsigned int number_blocks = ConvKernelDim + Stride ;
+    ap_uint<SIMD*Input_precision> inputBuf[number_blocks][IFMDim * multiplying_factor];
 #pragma HLS ARRAY_PARTITION variable=inputBuf complete dim=1
     memory_resource(inputBuf, r);
-	const unsigned int cycles_write_block = OFMDim * ConvKernelDim * ConvKernelDim * multiplying_factor;
-	const unsigned int cycles_read_block = IFMDim * Stride * multiplying_factor;
-	const unsigned int max_cycles = MAX(cycles_write_block, cycles_read_block);
-	const unsigned int baseIter = (IFMDim * ConvKernelDim * multiplying_factor) + (OFMDim-1) * max_cycles+MAX(cycles_write_block,OFMDim);
-	const unsigned int initial_buffer_cycles = (IFMDim * ConvKernelDim * multiplying_factor) ;
-	unsigned int counter_internal_block = 0;
-	unsigned int current_block_write = 0;
-#pragma HLS DEPENDENCE variable=current_block_write intra false
-#pragma HLS DEPENDENCE variable=current_block_write inter false
-
-	unsigned int next_block_write = 0;
-	unsigned int current_line = 0;
-	unsigned int read_block = 0;
-#pragma HLS RESET variable=read_block
-#pragma HLS DEPENDENCE variable=read_block intra false
-#pragma HLS DEPENDENCE variable=read_block inter false
-	unsigned int inp = 0, ofm_y = 0, ofm_x = 0, k_y = 0, k_x = 0, current_k_y = 0, count_simd =0;
+    const unsigned int cycles_write_block = OFMDim * ConvKernelDim * ConvKernelDim * multiplying_factor;
+    const unsigned int cycles_read_block = IFMDim * Stride * multiplying_factor;
+    const unsigned int max_cycles = MAX(cycles_write_block, cycles_read_block);
+    const unsigned int baseIter = (IFMDim * ConvKernelDim * multiplying_factor) + (OFMDim-1) * max_cycles+MAX(cycles_write_block,OFMDim);
+    const unsigned int initial_buffer_cycles = (IFMDim * ConvKernelDim * multiplying_factor) ;
+    unsigned int counter_internal_block = 0;
+    unsigned int next_block_write = 0;
+    unsigned int current_line = 0;
+    unsigned int inp = 0, ofm_y = 0, ofm_x = 0, k_y = 0, k_x = 0, current_k_y = 0, count_simd =0;
 #pragma HLS RESET variable=inp
-
+  
 #pragma HLS DEPENDENCE variable=inputBuf inter false
 #pragma HLS DEPENDENCE variable=inputBuf intra false
 
 // #pragma HLS RESOURCE variable inputBuf core=RAM_2P_LUTRAM
-for (unsigned int count_image = 0; count_image < numReps; count_image++) {
-		for (unsigned int i = 0; i < baseIter; i++) {
-	#pragma HLS PIPELINE II=1
-			if (inp < initial_buffer_cycles) // Initial buffer of PoolDim lines
-			{
-				ap_uint<SIMD*Input_precision> inElem;
-				inElem = in.read();
-				inputBuf[current_block_write][current_line] = inElem;
-				current_line++;
-				inp++;
-				if (current_line == IFMDim * multiplying_factor)
-				{
-					current_line = 0;
-					current_block_write++;
-					if (current_block_write == number_blocks)
-						current_block_write = 0;
-					read_block++;
-					counter_internal_block = 0;
-				}
-			}
-			else
-			{
-				if (counter_internal_block < cycles_write_block-1 || read_block==IFMDim) // We are writing output, MMV IFMChan per cycle
-				{
-					unsigned int current_block_read = (ofm_y*Stride + k_y)%number_blocks;
-					unsigned int current_line_in_block = (ofm_x * Stride + k_x)*multiplying_factor + count_simd;
-					ap_uint<SIMD*Input_precision> outElem = inputBuf[current_block_read][(current_line_in_block)];
-					out.write(outElem);
-					k_x++;
-					if (k_x == ConvKernelDim) {
-						k_x = 0;
-						k_y++;
-						if (k_y == ConvKernelDim) {
-							k_y = 0;
-							count_simd++;
-							if (count_simd == multiplying_factor) {
-								count_simd=0;	
-								ofm_x++;
-								if (ofm_x == OFMDim) {
-									ofm_x = 0;
-									ofm_y++;
-									if (ofm_y == OFMDim) {
-										ofm_y = 0;
-										inp = 0;
-									}
-								}
-							}
-						}
-					}
-				}
-				if ((counter_internal_block < cycles_read_block - 1) && (read_block<IFMDim)) // In parallel we write in the buffer, in the current block write if we still need to
-				{
-					ap_uint<SIMD*Input_precision> inElem;
-					inElem = in.read();
-					inputBuf[current_block_write][current_line] = inElem;
+  for (unsigned int count_image = 0; count_image < numReps; count_image++) {
+      unsigned int floor_block_read = 0, ceil_block_read = number_blocks;
+      unsigned int read_block = 0;
+      unsigned int current_block_write = 0;
+      for (unsigned int i = 0; i < baseIter; i++) {
+      #pragma HLS PIPELINE II=1
+
+      #pragma HLS DEPENDENCE variable=current_block_write intra false
+
+            if (inp < initial_buffer_cycles) // Initial buffer of PoolDim lines
+            {
+                ap_uint<SIMD*Input_precision> inElem;
+                inElem = in.read();
+                inputBuf[current_block_write][current_line] = inElem;
+                current_line++;
+                inp++;
+                if (current_line == IFMDim * multiplying_factor)
+                {
+                    current_line = 0;
+                    current_block_write++;
+                    if (current_block_write == number_blocks)
+                        current_block_write = 0;
+                    read_block++;
+                    counter_internal_block = 0;
+                }
+            }
+            else
+            {
+                if (counter_internal_block < cycles_write_block-1 || read_block==IFMDim) // We are writing output, MMV IFMChan per cycle
+                {
+          //following code implements: current_block_read = (ofm_y*Stride + k_y)%number_blocks;
+            unsigned int current_block_read = (ofm_y*Stride + k_y);
+            //reminder computation
+            if (current_block_read >= ceil_block_read)
+            {
+              floor_block_read += number_blocks;
+              ceil_block_read += number_blocks;
+            }else if(current_block_read < floor_block_read){
+              ceil_block_read -= number_blocks;
+              floor_block_read -= number_blocks;
+            }
+            current_block_read -= floor_block_read;
+
+                    unsigned int current_line_in_block = (ofm_x * Stride + k_x)*multiplying_factor + count_simd;
+                    ap_uint<SIMD*Input_precision> outElem = inputBuf[current_block_read][(current_line_in_block)];
+                    out.write(outElem);
+                    k_x++;
+                    if (k_x == ConvKernelDim) {
+                        k_x = 0;
+                        k_y++;
+                        if (k_y == ConvKernelDim) {
+                            k_y = 0;
+                            count_simd++;
+                            if (count_simd == multiplying_factor) {
+                                count_simd=0;   
+                                ofm_x++;
+                                if (ofm_x == OFMDim) {
+                                    ofm_x = 0;
+                                    ofm_y++;
+                                    if (ofm_y == OFMDim) {
+                                        ofm_y = 0;
+                                        inp = 0;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if ((counter_internal_block < cycles_read_block - 1) && (read_block<IFMDim)) // In parallel we write in the buffer, in the current block write if we still need to
+                {
+                    ap_uint<SIMD*Input_precision> inElem;
+                    inElem = in.read();
+                    inputBuf[current_block_write][current_line] = inElem;
 #pragma HLS DEPENDENCE variable=inputBuf inter false
 #pragma HLS DEPENDENCE variable=inputBuf intra false
-					current_line++;
-					if (current_line == IFMDim * multiplying_factor) // We read the whole block, we change the next block in which we want to we
-					{ // We filled up a block, let's not read until
-						current_line = 0;
-						read_block++;
-						current_block_write++;
-						if (current_block_write == number_blocks)
-							current_block_write = 0;
-	#pragma HLS DEPENDENCE variable=current_block_write intra false
-					}
-				}
-				counter_internal_block++; // = (counter_internal_block +1) % max_cycles;
+                    current_line++;
+                    if (current_line == IFMDim * multiplying_factor) // We read the whole block, we change the next block in which we want to we
+                    { // We filled up a block, let's not read until
+                        current_line = 0;
+                        read_block++;
+                        current_block_write++;
+                        if (current_block_write == number_blocks)
+                            current_block_write = 0;
+    #pragma HLS DEPENDENCE variable=current_block_write intra false
+                    }
+                }
+                counter_internal_block++; // = (counter_internal_block +1) % max_cycles;
                 if (counter_internal_block == (max_cycles-1))
-				{
-				   counter_internal_block = 0;
-				}
-			}
-		} // End base_iter
-		current_block_write=0;
-		read_block=0;
-    }
+                {
+                   counter_internal_block = 0;
+                }
+            }
+        } // End base_iter
+  }
 }
 
 


### PR DESCRIPTION
Both swg kernel stride (normal and dws versions) were modified to get a shorter pipe which allowed to remove problematic dependence pragmas and improve resource usage.