### PR TITLE
Fix bug in conv3_nonsquare_tb.cpp

### DIFF
--- a/tb/conv3_nonsquare_tb.cpp
+++ b/tb/conv3_nonsquare_tb.cpp
@@ -97,9 +97,10 @@ int main()
 	unsigned int ky=0;
 	unsigned int chan_count=0;
 	unsigned int out_chan_count=0;
-	for (unsigned int oy = 0; oy < TY; oy++) {
-		for (unsigned int ox = 0; ox <TX; ox++) {
-			for(int pe=0;pe <PE1;pe++){
+
+	for(int pe=0;pe <PE1;pe++){
+		for (unsigned int oy = 0; oy < TY; oy++) {
+			for (unsigned int ox = 0; ox <TX; ox++) {
 				for(int simd=0;simd<SIMD1;simd++){
 					W1[out_chan_count][kx][ky][chan_count] = PARAM::weights.weights(oy*TX + ox)[pe][simd];
 			    	chan_count++;

--- a/tb/gen_weigths_nonsquare.py
+++ b/tb/gen_weigths_nonsquare.py
@@ -52,8 +52,8 @@ ofm_dimension_x = 6
 ofm_dimension_y = 4
 
 activation_precision = 16
-simd = 1
-pe = 1
+simd = 2
+pe = 2
 w_precision = 4
 mmv=2
 


### PR DESCRIPTION
Hi, 
Thanks for your wonderful work!
After careful studing and testing, I find a bug in `tb/conv3_nonsquare_tb.cpp`. This bug is caused by the wrong loop nesting order.
The bug causes the `weights` to be error in testbench which causes the `EXP`(expected value) to be wrong, but it does not affect the hardware calculation results.  
