### PR TITLE
Add UpsamplingNearest layer

### DIFF
--- a/bnn-library.h
+++ b/bnn-library.h
@@ -63,3 +63,4 @@ using namespace std;
 #include "fclayer.h"
 #include "convlayer.h"
 #include "vvau.hpp"
+#include "upsample.hpp"

--- a/tb/test_upsample.tcl
+++ b/tb/test_upsample.tcl
@@ -1,3 +1,4 @@
+delete_project hls-syn-upsample
 open_project hls-syn-upsample
 add_files upsample_top.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb"
 add_files -tb upsample_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb"
@@ -7,5 +8,6 @@ set_part {xczu3eg-sbva484-1-i}
 create_clock -period 5 -name default
 csim_design
 csynth_design
-cosim_design -trace_level all -wave_debug
+cosim_design
+close_project
 exit

--- a/tb/test_upsample.tcl
+++ b/tb/test_upsample.tcl
@@ -7,5 +7,5 @@ set_part {xczu3eg-sbva484-1-i}
 create_clock -period 5 -name default
 csim_design
 csynth_design
-cosim_design
+cosim_design -trace_level all -wave_debug
 exit

--- a/tb/test_upsample.tcl
+++ b/tb/test_upsample.tcl
@@ -1,0 +1,11 @@
+open_project hls-syn-upsample
+add_files upsample_top.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb"
+add_files -tb upsample_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb"
+set_top Testbench_upsample
+open_solution sol1
+set_part {xczu3eg-sbva484-1-i}
+create_clock -period 5 -name default
+csim_design
+csynth_design
+cosim_design
+exit

--- a/tb/upsample_config.h
+++ b/tb/upsample_config.h
@@ -5,9 +5,9 @@
 #ifndef UPSAMPLE_CONFIG_H
 #define UPSAMPLE_CONFIG_H
 
-#define PRECISION 4
-#define FM_CHANNELS 4
-#define OFMDIM 64
-#define IFMDIM 32
+#define PRECISION 8
+#define FM_CHANNELS 3
+#define OFMDIM 4
+#define IFMDIM 2
 
 #endif //FINN_HLSLIB_UPSAMPLE_CONFIG_H

--- a/tb/upsample_config.h
+++ b/tb/upsample_config.h
@@ -1,0 +1,13 @@
+//
+// Created by erling on 5/10/21.
+//
+
+#ifndef UPSAMPLE_CONFIG_H
+#define UPSAMPLE_CONFIG_H
+
+#define PRECISION 4
+#define FM_CHANNELS 4
+#define OFMDIM 64
+#define IFMDIM 32
+
+#endif //FINN_HLSLIB_UPSAMPLE_CONFIG_H

--- a/tb/upsample_tb.cpp
+++ b/tb/upsample_tb.cpp
@@ -1,0 +1,88 @@
+//
+// Created by erling on 5/10/21.
+//
+
+
+#include <iostream>
+#include <hls_stream.h>
+#include "ap_int.h"
+#include "upsample_config.h"
+
+
+using namespace hls;
+using namespace std;
+
+
+
+void Testbench_upsample(stream<ap_uint<PRECISION * FM_CHANNELS>> &in, stream<ap_uint<PRECISION * FM_CHANNELS>> &out);
+
+void Golden_upsample(ap_uint<PRECISION> in[IFMDIM][IFMDIM][FM_CHANNELS], ap_uint<PRECISION> out[OFMDIM][OFMDIM][FM_CHANNELS]);
+
+int main(){
+  static ap_uint<PRECISION> golden_in[IFMDIM][IFMDIM][FM_CHANNELS];
+  static ap_uint<PRECISION> golden_out[OFMDIM][OFMDIM][FM_CHANNELS];
+
+  stream<ap_uint<PRECISION * FM_CHANNELS>> test_in("test_in");
+  stream<ap_uint<PRECISION * FM_CHANNELS>> test_out("test_out");
+
+  for (int i = 0; i<IFMDIM; i++) {
+    for (int j = 0; j<IFMDIM; j++) {
+      ap_uint<PRECISION*FM_CHANNELS> input_channel = 0;
+      for (int k = 0; k<FM_CHANNELS; k++) {
+        ap_uint<PRECISION> input = i*IFMDIM + j;
+        input_channel = input_channel << PRECISION;
+        input_channel(PRECISION-1,0) = input;
+        golden_in[i][j][k] = input;
+      }
+      test_in.write(input_channel);
+    }
+  }
+
+
+  Golden_upsample(golden_in, golden_out);
+  Testbench_upsample(test_in, test_out);
+
+  int err_counter = 0;
+  ap_uint<PRECISION> out_channel;
+  for (int i = 0; i<OFMDIM; i++) {
+    for (int j = 0; j<OFMDIM; j++) {
+      ap_uint<PRECISION * FM_CHANNELS> out_elem = test_out.read();
+      for (int k = 0; k<FM_CHANNELS; k++) {
+        ap_uint<PRECISION> expect = golden_out[i][j][k];
+        out_channel(PRECISION-1,0) = out_elem((k+1)*PRECISION-1, k*PRECISION);
+        if (expect != out_channel) {
+          cout << "ERROR: Expected["<<i<<"]["<<j<<"]["<<k<<"]=" <<expect <<" actual " <<out_channel <<endl;
+          err_counter++;
+        }
+      }
+    }
+  }
+
+  if (err_counter == 0) {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
+
+
+void Golden_upsample(ap_uint<PRECISION> in[IFMDIM][IFMDIM][FM_CHANNELS], ap_uint<PRECISION> out[OFMDIM][OFMDIM][FM_CHANNELS]) {
+  const int scaling = OFMDIM / IFMDIM;
+  const int padding = OFMDIM % IFMDIM;
+  for (int i = 0; i<OFMDIM; i++) {
+    for (int j = 0; j<OFMDIM; j++) {
+
+      int dst_i = i-padding;
+      if (dst_i<0) dst_i = 0;
+      int dst_j = j - padding;
+      if (dst_j<0) dst_j = 0;
+
+      int src_i = dst_i/scaling;
+      int src_j = dst_j/scaling;
+      for (int k = 0; k<FM_CHANNELS; k++) {
+        out[i][j][k] = in[src_i][src_j][k];
+      }
+    }
+  }
+}

--- a/tb/upsample_tb.cpp
+++ b/tb/upsample_tb.cpp
@@ -22,8 +22,8 @@ int main(){
   static ap_uint<PRECISION> golden_in[IFMDIM][IFMDIM][FM_CHANNELS];
   static ap_uint<PRECISION> golden_out[OFMDIM][OFMDIM][FM_CHANNELS];
 
-  stream<ap_uint<PRECISION * FM_CHANNELS>> test_in("test_in");
-  stream<ap_uint<PRECISION * FM_CHANNELS>> test_out("test_out");
+  stream<ap_uint<PRECISION*FM_CHANNELS>> test_in;
+  stream<ap_uint<PRECISION*FM_CHANNELS>> test_out;
 
   for (int i = 0; i<IFMDIM; i++) {
     for (int j = 0; j<IFMDIM; j++) {
@@ -42,8 +42,9 @@ int main(){
   Golden_upsample(golden_in, golden_out);
   Testbench_upsample(test_in, test_out);
 
-  int err_counter = 0;
+
   ap_uint<PRECISION> out_channel;
+  int err_counter = 0;
   for (int i = 0; i<OFMDIM; i++) {
     for (int j = 0; j<OFMDIM; j++) {
       ap_uint<PRECISION * FM_CHANNELS> out_elem = test_out.read();
@@ -58,12 +59,10 @@ int main(){
     }
   }
 
-  if (err_counter == 0) {
-    return 0;
-  } else {
-    return 1;
-  }
+  return err_counter;
 }
+
+
 
 
 

--- a/tb/upsample_top.cpp
+++ b/tb/upsample_top.cpp
@@ -1,0 +1,16 @@
+//
+// Created by erling on 5/10/21.
+//
+#include <hls_stream.h>
+using namespace hls;
+
+#include "ap_int.h"
+#include "../bnn-library.h"
+
+#include "upsample_config.h"
+
+
+
+void Testbench_upsample(stream<ap_uint<PRECISION * FM_CHANNELS>> &in, stream<ap_uint<PRECISION * FM_CHANNELS>> &out) {
+  UpsampleNearest<OFMDIM, IFMDIM, FM_CHANNELS, PRECISION>(in,out);
+}

--- a/upsample.hpp
+++ b/upsample.hpp
@@ -1,0 +1,109 @@
+//
+// Created by erling on 5/3/21.
+//
+
+#ifndef UPSAMPLE_HPP
+#define UPSAMPLE_HPP
+
+
+// UpsampleNearest
+//  Simple Upsamling layer implementing the most basic Nearest Neighbour upsampling assumes square IFM and OFM.
+//  This can be solved without using a SWU (which is needed for more complicated algorithms e.g. bilinear)
+//  Example: SIMD=1, IFMDim=2, OFMDim=5 => this gives scale_factor=2 padding=1. THis is consistent with PyTorch Upsample
+//            1 1 1 2 2
+//  1 2  ->   1 1 1 2 2
+//  3 4       1 1 1 2 2
+//            3 3 3 4 4
+//            3 3 3 4 4
+// This can be achieved by reading and buffering row 1 ([1 2]) and creating the output pattern:
+//  [1 1 1 2 2
+//   1 1 1 2 2
+//   1 1 1 2 2 ]
+// Notice that since we have "asymmetric" upsamling we pad the an extra "1" and also and extra "[1 1 1 2 2]" row.
+
+
+// This functions take a stream as input and produces one row as the output stream
+//  The idea is that you can either pass the top-level input stream or the row_buf fifo
+// to this function
+template<unsigned int OFMDim, unsigned int IFMDim, unsigned int SIMD, unsigned int Input_precision>
+void UpsampleNearestGenerateOutputRow(
+        stream<ap_uint<Input_precision * SIMD>> & in,
+        stream<ap_uint<Input_precision * SIMD>> & out,
+        stream<ap_uint<Input_precision * SIMD>> & out_row_buf,
+        bool write_row_buf
+        ) {
+  const unsigned int scale_factor = OFMDim/IFMDim;
+  const unsigned int padding = OFMDim % IFMDim;
+
+  for (unsigned int i = 0; i<IFMDim; i++) {
+    ap_uint<Input_precision * SIMD> in_elem;
+
+    in_elem = in.read();
+
+    // A bit hacky. But if we set the write_row_buf flag we will pass the input to the out_row_buf
+    //  output. So that it can also be stored in the row_buf
+    if (write_row_buf) {
+      out_row_buf.write(in_elem);
+    }
+
+    // Add padding
+    if (i == 0) {
+      for (unsigned int pad_idx = 0; pad_idx<padding; pad_idx++) {
+        out.write(in_elem);
+      }
+    }
+
+    // Duplicate input to the output stream
+    for (unsigned int scale_idx = 0; scale_idx < scale_factor; scale_idx++) {
+    	out.write(in_elem);
+    }
+  }
+}
+
+
+
+// Top level for the UpsampleNearest
+
+template<unsigned int OFMDim, unsigned int IFMDim, unsigned int SIMD, unsigned int Input_precision>
+void UpsampleNearest(
+        stream<ap_uint<Input_precision * SIMD>> & in,
+        stream<ap_uint<Input_precision * SIMD>> & out
+) {
+  CASSERT_DATAFLOW(OFMDim > IFMDim);
+
+  const unsigned int scale_factor = OFMDim/IFMDim;
+  const unsigned int padding = OFMDim % IFMDim;
+  const unsigned int base_iter = IFMDim;
+
+  // FIFO for temporary storing each row for duplication
+  stream<ap_uint<Input_precision * SIMD>> row_buf;
+
+  // Loop over the rows in the IFM
+  for (unsigned int row_idx = 0; row_idx < base_iter; row_idx++) {
+
+    if (row_idx == 0) {
+      // Add possible padding
+      for (int pad_idx = 0; pad_idx < padding; pad_idx++) {
+        // If we are at the first iteration through the padding: Use input stream
+        if (pad_idx == 0) {
+          UpsampleNearestGenerateOutputRow<OFMDim, IFMDim, SIMD, Input_precision>(in, out, row_buf, true);
+        } else {
+          UpsampleNearestGenerateOutputRow<OFMDim, IFMDim, SIMD, Input_precision>(row_buf, out, row_buf, true);
+        }
+      }
+    }
+    // Then do the rows. They are done "scale" number of times
+
+    for (unsigned int scale_idx = 0; scale_idx < scale_factor; scale_idx++) {
+    	bool write_row_buf = scale_idx < (scale_idx - 1);
+      if (scale_idx == 0 && !(row_idx == 0 && padding > 0)) {
+        // First iteration of a row is fetched from top-level input. Except if its the very first and we have padding
+        UpsampleNearestGenerateOutputRow<OFMDim, IFMDim, SIMD, Input_precision>(in, out, row_buf, write_row_buf);
+      } else {
+        UpsampleNearestGenerateOutputRow<OFMDim, IFMDim, SIMD, Input_precision>(row_buf, out, row_buf, write_row_buf);
+      }
+    }
+  }
+}
+
+#endif //FINN_HLSLIB_UPSAMPLE_HPP

--- a/upsample.hpp
+++ b/upsample.hpp
@@ -76,7 +76,7 @@ void UpsampleNearest(
   const unsigned int base_iter = IFMDim;
 
   // FIFO for temporary storing each row for duplication
-  stream<ap_uint<Input_precision * SIMD>> row_buf;
+  stream<ap_uint<Input_precision * SIMD>, IFMDim> row_buf;
 
   // Loop over the rows in the IFM
   for (unsigned int row_idx = 0; row_idx < base_iter; row_idx++) {


### PR DESCRIPTION
This PR adds a simple Upsampling layer with the Nearest Neighbor algorithm. It has no configuration parameters that the FINN compiler can tune. It reads C pixels each clock cycle from the input stream and duplicates thos pixels according to the scale factor. It also buffers each input row internally so it can duplicate also the rows. When the scale factor is not an integer it pads according to have PyTorch does it.

I gladly accept feedback on code structure, I am completely new to HLS and not yet sure of the compiler understands my intent. Functionally it should be correct (verified with C-sim and co-sim).