### PR TITLE
Add ConvolutionInputGenerator_1D_parallel for full SIMD unfolding

### DIFF
--- a/slidingwindow.h
+++ b/slidingwindow.h
@@ -36,6 +36,7 @@
  *           Thomas B. Preusser <thomas.preusser@utexas.edu>
  *             Marie-Curie Fellow, Xilinx Ireland, Grant Agreement No. 751339
  *           Christoph Doehring <cdoehrin@xilinx.com>
+ *           Felix Jentzsch <felix.jentzsch@upb.de>
  *
  *  \file slidingwindow.h
  *
@@ -1634,6 +1635,7 @@ void ConvolutionInputGenerator_NonSquare_Dilated(
  * \brief Sliding Window unit that produces output vectors for feeding
  * a Matrix_Vector_Activate_Batch, implementing the im2col algorithm.
  * To be used only for 1D feature maps.
+ * Feeds all pixels of the window in parallel for full SIMD unfolding of following layer.
  * NOTE: Currently restricted to: Stride = 1 and SIMD = IFMChannels
  *
  * \tparam ConvKernelDim    	Dimension of the convolutional kernel
@@ -1642,13 +1644,13 @@ void ConvolutionInputGenerator_NonSquare_Dilated(
  * \tparam IFMDim           	Height of the Input Feature Map
  * \tparam OFMDim           	Height of the Output Feature Map
  * \tparam SIMD             	Number of input columns computed in parallel
- * \tparam Stride          	    Stride of the convolutional kernel
+ * \tparam Stride          	  Stride of the convolutional kernel
  * \tparam R          	  		Datatype for the resource used for FPGA implementation of the SWG  - safely deducible from the parameters
  *
  * \param in                	Input stream
  * \param out               	Output stream
  * \param numReps           	Number of time the function has to be repeatedly executed (e.g. number of images)
- * \param r			  			Resource type for the hardware implementation of the memory block
+ * \param r			  			      Resource type for the hardware implementation of the memory block
 */
 template<unsigned int ConvKernelDim,
 		 unsigned int IFMChannels,
@@ -1658,7 +1660,7 @@ template<unsigned int ConvKernelDim,
 		 unsigned int SIMD,
 		 unsigned int Stride,
 		 typename R>
-void ConvolutionInputGenerator_1D(
+void ConvolutionInputGenerator_1D_parallel(
 		stream<ap_uint<SIMD*Input_precision> > & in,
 		stream<ap_uint<ConvKernelDim*SIMD*Input_precision> > & out,
 		const unsigned int numReps,

--- a/slidingwindow.h
+++ b/slidingwindow.h
@@ -1630,6 +1630,117 @@ void ConvolutionInputGenerator_NonSquare_Dilated(
   } // End count_image
 } // End generator
 
+/**
+ * \brief Sliding Window unit that produces output vectors for feeding
+ * a Matrix_Vector_Activate_Batch, implementing the im2col algorithm.
+ * To be used only for 1D feature maps.
+ * NOTE: Currently restricted to: Stride = 1 and SIMD = IFMChannels
+ *
+ * \tparam ConvKernelDim    	Dimension of the convolutional kernel
+ * \tparam IFMChannels      	Number of Input Feature Maps
+ * \tparam Input_precision  	Number bits per pixel
+ * \tparam IFMDim           	Height of the Input Feature Map
+ * \tparam OFMDim           	Height of the Output Feature Map
+ * \tparam SIMD             	Number of input columns computed in parallel
+ * \tparam Stride          	    Stride of the convolutional kernel
+ * \tparam R          	  		Datatype for the resource used for FPGA implementation of the SWG  - safely deducible from the parameters
+ *
+ * \param in                	Input stream
+ * \param out               	Output stream
+ * \param numReps           	Number of time the function has to be repeatedly executed (e.g. number of images)
+ * \param r			  			Resource type for the hardware implementation of the memory block
+*/
+template<unsigned int ConvKernelDim,
+		 unsigned int IFMChannels,
+		 unsigned int Input_precision,
+		 unsigned int IFMDim,
+		 unsigned int OFMDim,
+		 unsigned int SIMD,
+		 unsigned int Stride,
+		 typename R>
+void ConvolutionInputGenerator_1D(
+		stream<ap_uint<SIMD*Input_precision> > & in,
+		stream<ap_uint<ConvKernelDim*SIMD*Input_precision> > & out,
+		const unsigned int numReps,
+		R const &r) {
+
+  CASSERT_DATAFLOW(Stride == 1);
+  CASSERT_DATAFLOW(IFMChannels % SIMD == 0);
+  const unsigned int number_blocks = ConvKernelDim + 1 ;
+  ap_uint<SIMD*Input_precision> inputBuf[number_blocks];
+
+#pragma HLS ARRAY_PARTITION variable=inputBuf complete
+  //memory_resource(inputBuf, r); use reg regardless of setting
+  const unsigned int cycles_write_block = 1;
+  const unsigned int cycles_read_block = 1;
+  const unsigned int max_cycles = MAX(cycles_write_block,cycles_read_block);
+  const unsigned int baseIter = ConvKernelDim // Initial buffer
+			                  + OFMDim * MAX(cycles_write_block,cycles_read_block);
+  unsigned int current_block_write = 0;
+  unsigned int next_block_write = 0;
+  unsigned int read_block = 0;
+  unsigned int inp = 0, ofm_y = 0, k_y = 0;
+#pragma HLS reset variable=inp
+  for (unsigned int count_image = 0; count_image < numReps; count_image++) {
+    for (unsigned int i = 0; i < baseIter; i++) {
+#pragma HLS PIPELINE II=1
+      if (inp < ConvKernelDim) {// Initial buffer of ConvKernelDim lines
+        ap_uint<SIMD*Input_precision> inElem;
+        inElem = in.read();
+        inputBuf[current_block_write] = inElem;
+
+        inp++;
+
+        current_block_write++;
+        if (current_block_write == number_blocks) {
+          current_block_write=0;
+        }
+        read_block++;
+        
+      } else {
+        // READING from buffer
+
+        ap_uint<ConvKernelDim*SIMD*Input_precision> outElem;
+
+        for(int k_y=0; k_y<ConvKernelDim; k_y++)
+        {
+#pragma HLS UNROLL
+          unsigned int current_block_read = (current_block_write + 1 + k_y);
+          if (current_block_read >= number_blocks) {
+            current_block_read-= number_blocks;
+          }
+          outElem((k_y+1)*SIMD*Input_precision-1, k_y*SIMD*Input_precision) = inputBuf[current_block_read];
+        }
+
+        out.write(outElem);
+
+        ofm_y++;
+        if (ofm_y == OFMDim) {
+          ofm_y = 0;
+          inp = 0;
+        }
+        
+        if (read_block<IFMDim) { 
+          // WRITING to buffer
+          ap_uint<SIMD*Input_precision> inElem;
+          inElem = in.read();
+          inputBuf[current_block_write] = inElem;
+#pragma AP dependence variable=inputBuf intra false
+#pragma AP dependence variable=inputBuf inter false
+            
+          read_block++;
+          current_block_write++;
+          if (current_block_write == number_blocks) {
+            current_block_write=0;
+			    }
+#pragma AP dependence variable=current_block_write intra false
+          
+        }
+      }
+    } // End base_iter
+	read_block = 0;
+  } // End count_image
+} // End generator
 
 
 #endif

--- a/tb/input_gen_1D.cpp
+++ b/tb/input_gen_1D.cpp
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *  Copyright (c) 2021, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ *
+ *  Authors: Giulio Gambardella <giuliog@xilinx.com>
+ *           Felix Jentzsch <felix.jentzsch@upb.de>
+ *
+ *  \file input_gen_1D.cpp
+ *
+ *  HLS Top function with a single HLS sliding-window generator block unit testing (for 1D convolution)
+ *
+ *****************************************************************************/
+#define AP_INT_MAX_W 4096
+
+#include <hls_stream.h>
+using namespace hls;
+#include "ap_int.h"
+#include "bnn-library.h"
+#include "input_gen_1d.h"
+
+void Testbench(stream<ap_uint<IFM_Channels1*INPUT_PRECISION1> > & in, stream<ap_uint<KERNEL_DIM_y*IFM_Channels1*INPUT_PRECISION1> > & out)//, unsigned int numReps)
+{
+#pragma HLS DATAFLOW
+
+	ConvolutionInputGenerator_1D<KERNEL_DIM_y,
+	IFM_Channels1,
+	INPUT_PRECISION1,
+	IFMDim_y,
+	OFMDim_y,
+	SIMD1,
+	STRIDE_y>(in, out, 1, ap_resource_dflt());
+}

--- a/tb/input_gen_1d.h
+++ b/tb/input_gen_1d.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *  Copyright (c) 2021, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#define SIMD1 2
+#define KERNEL_DIM_x 1
+#define KERNEL_DIM_y 3
+#define IFM_Channels1 2
+#define IFMDim_x 1
+#define IFMDim_y 34
+#define OFMDim_x 1
+#define OFMDim_y 32
+#define STRIDE_x 1
+#define STRIDE_y 1
+#define INPUT_PRECISION1 8

--- a/tb/swg_1D_tb.cpp
+++ b/tb/swg_1D_tb.cpp
@@ -1,0 +1,111 @@
+/******************************************************************************
+ *  Copyright (c) 2021, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ *
+ *  Authors: Giulio Gambardella <giuliog@xilinx.com>
+ *           Felix Jentzsch <felix.jentzsch@upb.de>
+ *
+ *  \file swg_1D_tb.cpp
+ *
+ *  Testbench for the sliding window generator HLS block for 1D convolutions
+ *
+ *****************************************************************************/
+#define AP_INT_MAX_W 4096
+#include <hls_stream.h>
+#include "ap_int.h"
+#include <iostream>
+#include <string>
+#include "bnn-library.h"
+
+#include "input_gen_1d.h"
+
+#include "math.h"
+using namespace hls;
+using namespace std;
+
+#define MAX_IMAGES 1
+
+void Testbench(stream<ap_uint<IFM_Channels1*INPUT_PRECISION1> > & in, stream<ap_uint<KERNEL_DIM_y*IFM_Channels1*INPUT_PRECISION1> > & out); //, unsigned int numReps)
+
+int main()
+{
+	stream<ap_uint<IFM_Channels1*INPUT_PRECISION1> > input_stream("input_stream");
+	stream<ap_uint<IFM_Channels1*INPUT_PRECISION1> > output_stream("output_stream");
+	stream<ap_uint<KERNEL_DIM_y*IFM_Channels1*INPUT_PRECISION1> > output_stream_wide("output_stream_mmv");
+
+	static	ap_int<INPUT_PRECISION1> IMAGE[MAX_IMAGES][IFMDim_x][IFMDim_y][IFM_Channels1];
+	int counter = 0;
+	ap_uint<IFM_Channels1*INPUT_PRECISION1> input_channel = 0;
+	for(unsigned int n_image = 0; n_image < MAX_IMAGES; n_image++) {
+		for(unsigned int x = 0; x < IFMDim_x; x++) {
+			for(unsigned int y = 0; y < IFMDim_y; y++) {
+				input_channel = 0;
+				for(unsigned int c = 0; c < IFM_Channels1; c++) {
+					ap_int<INPUT_PRECISION1> input = (ap_int<INPUT_PRECISION1>)(counter+11);
+					IMAGE[n_image][x][y][c]= input;
+					input_channel = input_channel >> INPUT_PRECISION1;
+					input_channel(IFM_Channels1*INPUT_PRECISION1-1,(IFM_Channels1-1)*INPUT_PRECISION1)=input;
+					counter++;
+				}
+				input_stream.write(input_channel);
+			}
+		}
+	}
+	Testbench(input_stream, output_stream_wide);//, MAX_IMAGES);
+	StreamingDataWidthConverter_Batch<KERNEL_DIM_y*IFM_Channels1*INPUT_PRECISION1, IFM_Channels1*INPUT_PRECISION1, IFMDim_y>(output_stream_wide, output_stream, 1);
+
+	ap_int<INPUT_PRECISION1> out_chan;
+	int expected_value;
+	for(unsigned int n_image = 0; n_image < MAX_IMAGES; n_image++) {
+		for(unsigned int ox = 0; ox < OFMDim_x; ox++) {
+			for(unsigned int oy = 0; oy < OFMDim_y; oy++) {
+				for(unsigned int kx = 0; kx < KERNEL_DIM_x; kx++) {
+					for(unsigned int ky = 0; ky < KERNEL_DIM_y; ky++) {
+						ap_uint<INPUT_PRECISION1*IFM_Channels1> outElem = output_stream.read();
+						for(unsigned int chan = 0; chan < IFM_Channels1; chan++) {
+							out_chan(INPUT_PRECISION1-1,0) = outElem((chan + 1)*INPUT_PRECISION1-1,chan*INPUT_PRECISION1);
+							int output_value = (ap_int<INPUT_PRECISION1>) out_chan;
+							expected_value = (ap_int<INPUT_PRECISION1>) IMAGE[n_image][ox+kx*1][oy+ky*1][chan];
+							if (output_value != expected_value){
+								std::cout << "ERROR: Expected " << expected_value << " actual " <<  output_value << std::endl;
+								std::cout << "Position: OFMDim_x " << ox << " OFMDim_y " << oy <<  " KERNEL_DIM_x " <<  kx << " KERNEL_DIM_y " << ky << " IFM_Channels1 " <<  chan << " Image " << n_image << std::endl;
+								return 1;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return 0;
+}

--- a/tb/test_swg_1D.tcl
+++ b/tb/test_swg_1D.tcl
@@ -1,0 +1,51 @@
+##############################################################################
+ #  Copyright (c) 2021, Xilinx, Inc.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions are met:
+ #
+ #  1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ #  2.  Redistributions in binary form must reproduce the above copyright
+ #      notice, this list of conditions and the following disclaimer in the
+ #      documentation and/or other materials provided with the distribution.
+ #
+ #  3.  Neither the name of the copyright holder nor the names of its
+ #      contributors may be used to endorse or promote products derived from
+ #      this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ #  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ #  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ #  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ #  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ #  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+###############################################################################
+###############################################################################
+ #
+ #  Authors: Giulio Gambardella <giuliog@xilinx.com>
+ #
+ # \file test_swg_1D.tcl
+ #
+ # Tcl script for HLS csim, synthesis and cosim of the sliding window generator block for 1D convolutions
+ #
+###############################################################################
+open_project hls-syn-swg-1d
+add_files input_gen_1D.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT)" 
+add_files -tb swg_1D_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT)" 
+set_top Testbench
+open_solution sol1
+set_part {xczu3eg-sbva484-1-i}
+create_clock -period 5 -name default
+csim_design
+csynth_design
+cosim_design
+exit


### PR DESCRIPTION
Adds a new ConvolutionInputGenerator variant for 1D feature maps. It feeds all pixels of the window in parallel to enable full SIMD unfolding of following layer. The output stream width is `ConvKernelDim*SIMD*Input_precision` instead of the `SIMD*Input_precision` found in the existing "NonSquare" variants. Buffering has been minimized to `ConvKernelDim+1`.

Current restrictions:
- Stride = 1
- SIMD = IFMChannels
- Does not support dilation or depthwise-separable mode