### PR TITLE
Migrate all channelwise functions to own namespace + extend datatypes

### DIFF
--- a/activations.hpp
+++ b/activations.hpp
@@ -74,6 +74,9 @@ namespace comp{
   template<typename input_type_1 = void, typename input_type_2 = void, typename result_type = void>
     struct mul;	
 
+  template<typename input_type_1 = void, typename input_type_2 = void, typename result_type = void>
+    struct max;
+
   template<typename input_type>
     struct greater : public binary_function<input_type_1, input_type_2, ap_uint<1>> {
       ap_uint<1>
@@ -114,6 +117,13 @@ namespace comp{
       result_type
       operator()(const input_type_1& a, const input_type_2& b) const
       { return a * b; }
+    };
+
+  template<typename input_type>
+    struct max : public binary_function<input_type_1, input_type_2, result_type> {
+      result_type
+      operator()(const input_type_1& a, const input_type_2& b) const
+      { return a > b ? a : b; }
     };
 }
 
@@ -225,7 +235,7 @@ public:
  */
 
 template<unsigned NF, unsigned PE,
-   typename TI, typename TP, typename TR, typename Fxn = std::multiplies<TR>>
+   typename TI, typename TP, typename TR, typename Fxn = comp::mul<TI, TP, TR>>
 class ChannelWiseOperation {
 public:
   TP parameters[PE][NF];

--- a/activations.hpp
+++ b/activations.hpp
@@ -56,46 +56,65 @@
 
 namespace comp{
 
-  template<typename input_type = void>
+  template<typename input_type_1 = void, typename input_type_2 = void>
     struct greater;
 
-  template<typename input_type = void>
+  template<typename input_type_1 = void, typename input_type_2 = void>
     struct less;
 
-  template<typename input_type = void>
+  template<typename input_type_1 = void, typename input_type_2 = void>
     struct greater_equal;
 
-  template<typename input_type = void>
-    struct less_equal;	
+  template<typename input_type_1 = void, typename input_type_2 = void>
+    struct less_equal;
+
+  template<typename input_type_1 = void, typename input_type_2 = void, typename result_type = void>
+    struct add;	
+
+  template<typename input_type_1 = void, typename input_type_2 = void, typename result_type = void>
+    struct mul;	
 
   template<typename input_type>
-    struct greater : public binary_function<input_type, input_type, ap_uint<1>> {
+    struct greater : public binary_function<input_type_1, input_type_2, ap_uint<1>> {
       ap_uint<1>
-      operator()(const input_type& a, const input_type& b) const
+      operator()(const input_type_1& a, const input_type_2& b) const
       { return a > b; }
     };
 
   template<typename input_type>
-    struct less : public binary_function<input_type, input_type, ap_uint<1>> {
+    struct less : public binary_function<input_type_1, input_type_2, ap_uint<1>> {
       ap_uint<1>
-      operator()(const input_type& a, const input_type& b) const
+      operator()(const input_type_1& a, const input_type_2& b) const
       { return a < b; }
     };
 
   template<typename input_type>
-    struct greater_equal : public binary_function<input_type, input_type, ap_uint<1>> {
+    struct greater_equal : public binary_function<input_type_1, input_type_2, ap_uint<1>> {
       ap_uint<1>
-      operator()(const input_type& a, const input_type& b) const
+      operator()(const input_type_1& a, const input_type_2& b) const
       { return a >= b; }
     };
 
   template<typename input_type>
-    struct less_equal : public binary_function<input_type, input_type, ap_uint<1>> {
+    struct less_equal : public binary_function<input_type_1, input_type_2, ap_uint<1>> {
       ap_uint<1>
-      operator()(const input_type& a, const input_type& b) const
+      operator()(const input_type_1& a, const input_type_2& b) const
       { return a <= b; }
     };
 	
+  template<typename input_type>
+    struct add : public binary_function<input_type_1, input_type_2, result_type> {
+      result_type
+      operator()(const input_type_1& a, const input_type_2& b) const
+      { return a + b; }
+    };
+
+  template<typename input_type>
+    struct mul : public binary_function<input_type_1, input_type_2, result_type> {
+      result_type
+      operator()(const input_type_1& a, const input_type_2& b) const
+      { return a * b; }
+    };
 }
 
 /**
@@ -140,7 +159,7 @@ public:
  * The default comparison returns true if the threshold value is
  * smaller than the passed accumulator value.
  */
-template<typename TA, typename Compare = comp::less<TA>>
+template<typename TA, typename Compare = comp::less<TA, TA>>
 class ThresholdActivation : public Activation<TA, bool> {
   TA const  m_threshold;
 public:
@@ -166,7 +185,7 @@ public:
  * the indexed row is smaller than the passed accumulator value.
  */
 template<unsigned NF, unsigned PE, unsigned NumTH, 
-	 typename TA, typename TR, int ActVal = 0, typename Compare = comp::less<TA>>
+	 typename TA, typename TR, int ActVal = 0, typename Compare = comp::less<TA, TA>>
 class ThresholdsActivation {
 public:
   TA m_thresholds[PE][NF][NumTH];
@@ -320,7 +339,7 @@ void Thresholding_Stream_Batch(hls::stream<TI> &in,
   // alternatively: number of vertical matrix chunks
   unsigned const NF = NumChannels / PE;
 
-  ThresholdsActivation<1, PE, NumSteps, TT, TO, ActVal, comp::less_equal<TT>> internal_thr;
+  ThresholdsActivation<1, PE, NumSteps, TT, TO, ActVal, comp::less_equal<TT, TT>> internal_thr;
   #pragma HLS ARRAY_PARTITION variable=internal_thr.m_thresholds complete dim=0
 
   // everything merged into a common iteration space (one "big" loop instead

--- a/pool.hpp
+++ b/pool.hpp
@@ -108,7 +108,7 @@ T init(void) const {
 */
   T pool(T const &input, T const &accu) const{
 #pragma HLS inline
-    return std::max(input,accu);
+    return comp::max<T, T, T>(input,accu);
   }
 /*!
  * \brief activate: compute the output of the max pooling algorithm
@@ -142,7 +142,7 @@ public:
 */
   TA pool(TA const &input, TA const &accu) const{
 #pragma HLS inline
-    return std::plus<TA>()(input,accu);
+    return comp::add<TA, TA, TA>()(input,accu);
   }
 /*!
  * \brief activate: compute the output of the avg pooling algorithm
@@ -176,7 +176,7 @@ public:
 */
   TA pool(TA const &input, TA const &accu) const{
 #pragma HLS inline
-    return std::plus<TA>()(input,accu);
+    return comp::add<TA, TA, TA>()(input,accu);
   }
 /*!
  * \brief activate: compute the output of the max pooling algorithm

--- a/tb/channelwise_op_top.cpp
+++ b/tb/channelwise_op_top.cpp
@@ -67,7 +67,7 @@ void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in,
 
     // [add] 
     ChannelWiseOperation<FOLD, PE,BIPO_OUT_TYPE, ADD_PARAM_TYPE, ADD_OUT_TYPE, 
-            std::plus<ADD_OUT_TYPE> > add_params = {.parameters = ADD_INIT};
+            comp::add<ADD_PARAM_TYPE, ADD_PARAM_TYPE, ADD_OUT_TYPE> > add_params = {.parameters = ADD_INIT};
     
     stream<ap_uint<PE*ADD_OUT_BITS>>  add_out;
     Thresholding_Batch< IFMDim, IFM_Channels, PE,
@@ -77,7 +77,7 @@ void Testbench_channelwise_op(stream<ap_uint<IFM_Channels*INPUT_BITS> > & in,
 
     // [mult] 
     ChannelWiseOperation<FOLD, PE,ADD_OUT_TYPE, MULT_PARAM_TYPE, MULT_OUT_TYPE, 
-            std::multiplies<MULT_OUT_TYPE> > mult_params= {.parameters = MULT_INIT};
+            comp::mul<MULT_PARAM_TYPE, MULT_PARAM_TYPE, MULT_OUT_TYPE> > mult_params= {.parameters = MULT_INIT};
     
     stream<ap_uint<PE*MULT_OUT_BITS>>  mul_out;
     Thresholding_Batch< IFMDim, IFM_Channels, PE,


### PR DESCRIPTION
* Switch all channelwise functions to `comp::` namespace since 2021.2 raises synth errors for certain `std::` functions
* Allow specifying different input datatypes for comparator functions, input and output datatypes for `add` and `mul`