### PR TITLE
Optimized 1D depthwise SWU

### DIFF
--- a/slidingwindow.h
+++ b/slidingwindow.h
@@ -1779,19 +1779,19 @@ void ConvolutionInputGenerator_1D_dws_naive(
 		R const &r) {
   CASSERT_DATAFLOW(IFMChannels % SIMD == 0);
 
-  const unsigned int multiplying_factor = IFMChannels / SIMD;
-  const unsigned int cycles_write_block = OFMDim_x * ConvKernelDim_x * multiplying_factor;
-  const unsigned int cycles_read_block = IFMDim_x * multiplying_factor;
+  constexpr unsigned multiplying_factor = IFMChannels / SIMD;
+  constexpr unsigned cycles_write_block = OFMDim_x * ConvKernelDim_x * multiplying_factor;
+  constexpr unsigned cycles_read_block = IFMDim_x * multiplying_factor;
   ap_uint<SIMD*Input_precision> inputBuf[cycles_read_block];
   memory_resource(inputBuf, r);
-  const unsigned int baseIter = cycles_read_block // Initial buffer
+  constexpr unsigned baseIter = cycles_read_block // Initial buffer
 			                  + cycles_write_block;
   unsigned int current_line = 0;
   unsigned int inp = 0, ofm_x = 0, k_x = 0, count_simd =0;
 #pragma HLS reset variable=inp
   for (unsigned int count_image = 0; count_image < numReps; count_image++) {
     for (unsigned int i = 0; i < baseIter; i++) {
-#pragma HLS PIPELINE II=1 style=frp
+#pragma HLS PIPELINE II=1 style=flp
       if (inp < cycles_read_block) {// Initial buffer of ConvKernelDim lines
         ap_uint<SIMD*Input_precision> inElem;
         inElem = in.read();
@@ -1875,7 +1875,7 @@ void ConvolutionInputGenerator_1D(
 		unsigned  offset = 0;
 		unsigned  inp_count = 0;
 		for(unsigned  i = 0; i < 1+OUTPUT_SIZE; i++) {
-#pragma HLS PIPELINE II=1 style=frp
+#pragma HLS PIPELINE II=1 style=flp
 			bool const  re = i > 0;
 			bool const  we = (i < WINDOW_SIZE) || (ocnt < SIMD_COUNT * Stride_x);
 			if(re) {
@@ -1951,7 +1951,7 @@ void ConvolutionInputGenerator_1D_dws(
 		unsigned  inp_count = 0;
 		unsigned  wcnt = 0;
 		for(unsigned  i = 0; i < 1 + READ_CYCLES + OUTPUT_SIZE; i++) {
-#pragma HLS PIPELINE II=1 style=frp
+#pragma HLS PIPELINE II=1 style=flp
 			bool const  re = i > READ_CYCLES;
 			bool const  we = (i < BUFFER_SIZE) || (ocnt < SIMD_COUNT);
 			if(re) {
@@ -2030,7 +2030,7 @@ void ConvolutionInputGenerator_1D_dws_stride(
 		unsigned  inp_count = 0;
 		unsigned  wcnt = 0;
 		for(unsigned  i = 0; i < 1 + READ_CYCLES + OUTPUT_SIZE; i++) {
-#pragma HLS PIPELINE II=1 style=frp
+#pragma HLS PIPELINE II=1 style=flp
 			bool const  re = i > READ_CYCLES;
 			bool const  we = (i < BUFFER_SIZE) || (ocnt < SIMD_COUNT * Stride_x);
 			if(re) {

--- a/tb/data/input_gen_1d_dws.h
+++ b/tb/data/input_gen_1d_dws.h
@@ -29,33 +29,12 @@
  *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  ******************************************************************************/
-/******************************************************************************
- *
- *  Authors: Giulio Gambardella <giuliog@xilinx.com>
- *           Felix Jentzsch <felix.jentzsch@upb.de>
- *
- *  \file input_gen_1D.cpp
- *
- *  HLS Top function with a single HLS sliding-window generator block unit testing (for 1D convolution)
- *
- *****************************************************************************/
-#define AP_INT_MAX_W 4096
 
-#include <hls_stream.h>
-using namespace hls;
-#include "ap_int.h"
-#include "bnn-library.h"
-#include "data/input_gen_1d.h"
-
-void Testbench(stream<ap_uint<SIMD1*INPUT_PRECISION1> > & in, stream<ap_uint<SIMD1*INPUT_PRECISION1> > & out)//, unsigned int numReps)
-{
-#pragma HLS DATAFLOW
-
-	ConvolutionInputGenerator_1D<KERNEL_DIM_x,
-	IFM_Channels1,
-	INPUT_PRECISION1,
-	IFMDim_x,
-	OFMDim_x,
-	STRIDE_x,
-	SIMD1>(in, out, 1, ap_resource_dflt());
-}
+#define SIMD1 1
+#define KERNEL_DIM_x 5
+#define IFM_Channels1 12
+#define IFMDim_x 20
+#define OFMDim_x 16
+#define STRIDE_x 1
+#define DILATION_x 1
+#define INPUT_PRECISION1 16

--- a/tb/input_gen_1D_dws.cpp
+++ b/tb/input_gen_1D_dws.cpp
@@ -45,17 +45,16 @@
 using namespace hls;
 #include "ap_int.h"
 #include "bnn-library.h"
-#include "data/input_gen_1d.h"
+#include "data/input_gen_1d_dws.h"
 
 void Testbench(stream<ap_uint<SIMD1*INPUT_PRECISION1> > & in, stream<ap_uint<SIMD1*INPUT_PRECISION1> > & out)//, unsigned int numReps)
 {
 #pragma HLS DATAFLOW
 
-	ConvolutionInputGenerator_1D<KERNEL_DIM_x,
+	ConvolutionInputGenerator_1D_dws<KERNEL_DIM_x,
 	IFM_Channels1,
 	INPUT_PRECISION1,
 	IFMDim_x,
 	OFMDim_x,
-	STRIDE_x,
 	SIMD1>(in, out, 1, ap_resource_dflt());
 }

--- a/tb/swg_1D_dws_tb.cpp
+++ b/tb/swg_1D_dws_tb.cpp
@@ -1,0 +1,107 @@
+/******************************************************************************
+ *  Copyright (c) 2021, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ *
+ *  Authors: Mirza Mrahorovic <mirzam@xilinx.com>
+ *
+ *  \file swg_1D_dws_tb.cpp
+ *
+ *  Testbench for the sliding window generator HLS block for 1D convolutions
+ *
+ *****************************************************************************/
+#define AP_INT_MAX_W 4096
+#include <hls_stream.h>
+#include "ap_int.h"
+#include <iostream>
+#include <string>
+#include "bnn-library.h"
+
+#include "data/input_gen_1d_dws.h"
+
+#include "math.h"
+using namespace hls;
+using namespace std;
+
+#define MAX_IMAGES 1
+
+void Testbench(stream<ap_uint<SIMD1*INPUT_PRECISION1> > & in, stream<ap_uint<SIMD1*INPUT_PRECISION1> > & out);
+
+int main()
+{
+	stream<ap_uint<IFM_Channels1*INPUT_PRECISION1> > input_stream("input_stream");
+	stream<ap_uint<IFM_Channels1*INPUT_PRECISION1> > output_stream("output_stream");
+	stream<ap_uint<SIMD1*INPUT_PRECISION1> > in_simd("in_simd");
+	stream<ap_uint<SIMD1*INPUT_PRECISION1> > out_simd("out_simd");
+
+	static	ap_int<INPUT_PRECISION1> IMAGE[MAX_IMAGES][IFMDim_x][IFM_Channels1];
+	int counter = 0;
+	ap_uint<SIMD1*INPUT_PRECISION1> input_channel = 0;
+	for(unsigned int n_image = 0; n_image < MAX_IMAGES; n_image++) {
+		for(unsigned int x = 0; x < IFMDim_x; x++) {
+            for(unsigned int c = 0; c < IFM_Channels1/SIMD1; c++) {
+                input_channel = 0;
+                for(unsigned int s = 0; s < SIMD1; s++){
+                    ap_int<INPUT_PRECISION1> input = (ap_int<INPUT_PRECISION1>)(counter);
+                    IMAGE[n_image][x][c*SIMD1+s]= input;
+                    input_channel = input_channel >> INPUT_PRECISION1;
+                    input_channel(SIMD1*INPUT_PRECISION1-1,(SIMD1-1)*INPUT_PRECISION1)=input;
+                    counter++;
+                }
+                in_simd.write(input_channel);
+            }
+		}
+	}
+	Testbench(in_simd, out_simd);
+
+	ap_int<INPUT_PRECISION1> out_chan;
+	int expected_value;
+	for(unsigned int n_image = 0; n_image < MAX_IMAGES; n_image++) {
+		for(unsigned int ox = 0; ox < OFMDim_x; ox++) {
+            for(unsigned int chan = 0; chan < IFM_Channels1/SIMD1; chan++) {
+                for(unsigned int kx = 0; kx < KERNEL_DIM_x; kx++) {
+                    ap_uint<SIMD1*INPUT_PRECISION1> outElem = out_simd.read();
+                    for(unsigned int s = 0; s < SIMD1; s++){
+                        out_chan(INPUT_PRECISION1-1,0) = outElem((s + 1)*INPUT_PRECISION1-1,s*INPUT_PRECISION1);
+                        expected_value = (ap_int<INPUT_PRECISION1>) IMAGE[n_image][ox*STRIDE_x+kx*DILATION_x][SIMD1*chan+s];
+                        if (out_chan != expected_value){
+                            std::cout << "ERROR: Expected " << expected_value << " actual " <<  out_chan << std::endl;
+                            std::cout << "Position: OFMDim_x " << ox <<  " KERNEL_DIM_x " <<  kx << " IFM_Channels1/SIMD1 " <<  chan << " SIMD " << s << std::endl;
+                            return 1;
+                            }
+                        }
+                }
+            }
+        }
+	}
+
+	return 0;
+}

--- a/tb/test_swg_1D_dws.tcl
+++ b/tb/test_swg_1D_dws.tcl
@@ -1,0 +1,51 @@
+##############################################################################
+ #  Copyright (c) 2021, Xilinx, Inc.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions are met:
+ #
+ #  1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ #  2.  Redistributions in binary form must reproduce the above copyright
+ #      notice, this list of conditions and the following disclaimer in the
+ #      documentation and/or other materials provided with the distribution.
+ #
+ #  3.  Neither the name of the copyright holder nor the names of its
+ #      contributors may be used to endorse or promote products derived from
+ #      this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ #  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ #  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ #  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ #  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ #  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+###############################################################################
+###############################################################################
+ #
+ #  Authors: Mirza Mrahorovic <mirzamg@xilinx.com>
+ #
+ # \file test_swg_1D_dws.tcl
+ #
+ # Tcl script for HLS csim, synthesis and cosim of the sliding window generator block for 1D convolutions
+ #
+###############################################################################
+open_project hls-syn-swg-1d
+add_files input_gen_1D_dws.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)" 
+add_files -tb swg_1D_dws_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)" 
+set_top Testbench
+open_solution sol1
+set_part {xczu3eg-sbva484-1-i}
+create_clock -period 5 -name default
+csim_design
+csynth_design
+cosim_design
+exit


### PR DESCRIPTION
Added/renamed 1D SWUs:

- `ConvolutionInputGenerator_1D_dilated_dws`: renamed to `ConvolutionInputGenerator_1D_naive`, supports all combinations of stride/dilation, but the buffer size is not optimized (entire input image is buffered).
- `ConvolutionInputGenerator_1D_dws`: optimized variant of a 1D depthwise SWU.
- `ConvolutionInputGenerator_1D_dws_stride`: optimized variant of a 1D depthwise SWU supporting stride=2.
- `ConvolutionInputGenerator_1D_lowbuffer`: renamed to `ConvolutionInputGenerator_1D`.

Left to do:
- `ConvolutionInputGenerator_1D_dilated`: optimized variant of a 1D non-depthwise SWU for dilated convolutions.
- `ConvolutionInputGenerator_1D_dws_dilated`: optimized variant of a 1D depthwise SWU for dilated convolutions.
- Creating a `ConvolutionInputGenerator_1D_dws_stride` that supports stride>2 and optimizes the buffer size.