### PR TITLE
Fix to InpPerImage const

### DIFF
--- a/convlayer.h
+++ b/convlayer.h
@@ -112,7 +112,7 @@ void ConvLayer_Batch(hls::stream<ap_uint<InStreamW>>  &in,
 #pragma HLS INLINE
   unsigned const MatrixW = ConvKernelDim * ConvKernelDim * IFMChannels;
   unsigned const MatrixH = OFMChannels;
-  unsigned const InpPerImage = IFMDim*IFMDim*IFMChannels/InStreamW * TSrcI::width;
+  unsigned const InpPerImage = IFMDim*IFMDim*IFMChannels*TSrcI::width/InStreamW;
   hls::stream<ap_uint<SIMD*TSrcI::width> > wa_in("StreamingConvLayer_Batch.wa_in");
   hls::stream<ap_uint<SIMD*TSrcI::width> > convInp("StreamingConvLayer_Batch.convInp");
   hls::stream<ap_uint<PE*TDstI::width> > mvOut("StreamingConvLayer_Batch.mvOut");

--- a/tb/conv3_tb.cpp
+++ b/tb/conv3_tb.cpp
@@ -49,7 +49,7 @@
 #include "weights.hpp"
 #include "bnn-library.h"
 #include "data/memdata.h"
-#include "config.h"
+#include "data/config.h"
 #include "activations.hpp"
 #include "weights.hpp"
 #include "activations.hpp"

--- a/tb/conv_top.cpp
+++ b/tb/conv_top.cpp
@@ -50,7 +50,7 @@ using namespace hls;
 #include "mvau.hpp"
 #include "conv.hpp"
 #include "data/memdata.h"
-#include "config.h"
+#include "data/config.h"
 
 void Testbench_conv(stream<ap_uint<IFM_Channels1*INPUT_PRECISION> > & in, stream<ap_uint<OFM_Channels1*ACTIVATION_PRECISION> > & out, unsigned int numReps){
 #pragma HLS DATAFLOW


### PR DESCRIPTION
Compiler evaluates this by plugging in the numbers instead of recognizing that InStreamW == IFMChannels*TSrcI::width.
By changing the order, InpPerImage is correctly calculated.