### PR TITLE
Minor fixes to testbench scripts

### DIFF
--- a/slidingwindow.h
+++ b/slidingwindow.h
@@ -72,7 +72,6 @@
  */
 template <typename T>
 void memory_resource(T inputBuf, ap_resource_dflt const&){
-#pragma HLS inline
 #pragma HLS BIND_STORAGE variable=inputBuf type=RAM_2P
 }
 /**
@@ -94,7 +93,6 @@ void memory_resource(T inputBuf, ap_resource_dflt const&){
  */
 template <typename T>
 void memory_resource(T inputBuf, ap_resource_bram const&){
-#pragma HLS inline
 #pragma HLS BIND_STORAGE variable=inputBuf type=RAM_S2P impl=BRAM
 }
 /**
@@ -116,7 +114,6 @@ void memory_resource(T inputBuf, ap_resource_bram const&){
  */
 template <typename T>
 void memory_resource(T inputBuf, ap_resource_uram const&){
-#pragma HLS inline
 #pragma HLS BIND_STORAGE variable=inputBuf type=RAM_S2P impl=URAM
 }
 /**
@@ -138,7 +135,6 @@ void memory_resource(T inputBuf, ap_resource_uram const&){
  */
 template <typename T>
 void memory_resource(T inputBuf, ap_resource_lutram const&){
-#pragma HLS inline
 #pragma HLS BIND_STORAGE variable=inputBuf type=RAM_S2P impl=LUTRAM
 }
 

--- a/tb/add_tb.cpp
+++ b/tb/add_tb.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/channelwise_op_tb.cpp
+++ b/tb/channelwise_op_tb.cpp
@@ -46,7 +46,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/conv3_nonsquare_dws_tb.cpp
+++ b/tb/conv3_nonsquare_dws_tb.cpp
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/conv3_nonsquare_tb.cpp
+++ b/tb/conv3_nonsquare_tb.cpp
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/conv3_stmr_inj_tb.cpp
+++ b/tb/conv3_stmr_inj_tb.cpp
@@ -40,7 +40,7 @@
  *  Testbench for the HLS block which performs conv. using redundancy checks
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include <iostream>
 #include <fstream>
 #include <time.h>

--- a/tb/conv3_stmr_noinj_tb.cpp
+++ b/tb/conv3_stmr_noinj_tb.cpp
@@ -40,7 +40,7 @@
  *  Testbench for the HLS block which performs conv. using redundancy checks
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include <iostream>
 #include <fstream>
 #include <time.h>

--- a/tb/conv3_tb.cpp
+++ b/tb/conv3_tb.cpp
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/conv3mmv_tb.cpp
+++ b/tb/conv3mmv_tb.cpp
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/conv_dws_tb.cpp
+++ b/tb/conv_dws_tb.cpp
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 4096
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/conv_dws_top.cpp
+++ b/tb/conv_dws_top.cpp
@@ -41,7 +41,7 @@
  *****************************************************************************/
 #include <hls_stream.h>
 using namespace hls;
-#define AP_INT_MAX_W 4096
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "bnn-library.h"
 

--- a/tb/dup_stream_tb.cpp
+++ b/tb/dup_stream_tb.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/dwc_tb.cpp
+++ b/tb/dwc_tb.cpp
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/dwcnm_tb.cpp
+++ b/tb/dwcnm_tb.cpp
@@ -47,7 +47,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "bnn-library.h"
 

--- a/tb/input_gen_1D.cpp
+++ b/tb/input_gen_1D.cpp
@@ -40,7 +40,7 @@
  *  HLS Top function with a single HLS sliding-window generator block unit testing (for 1D convolution)
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 4096
+#define AP_INT_MAX_W 8191
 
 #include <hls_stream.h>
 using namespace hls;

--- a/tb/input_gen_1D_dws.cpp
+++ b/tb/input_gen_1D_dws.cpp
@@ -40,7 +40,7 @@
  *  HLS Top function with a single HLS sliding-window generator block unit testing (for 1D convolution)
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 4096
+#define AP_INT_MAX_W 8191
 
 #include <hls_stream.h>
 using namespace hls;

--- a/tb/kernel_stride_maxpool_tb.cpp
+++ b/tb/kernel_stride_maxpool_tb.cpp
@@ -47,7 +47,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/label_select_tb.cpp
+++ b/tb/label_select_tb.cpp
@@ -46,7 +46,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/maxpool_1d_tb.cpp
+++ b/tb/maxpool_1d_tb.cpp
@@ -46,7 +46,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/maxpool_tb.cpp
+++ b/tb/maxpool_tb.cpp
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <hls_stream.h>
 #include <cstdlib>
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include "ap_int.h"
 #include "weights.hpp"
 #include "bnn-library.h"

--- a/tb/swg_1D_dws_tb.cpp
+++ b/tb/swg_1D_dws_tb.cpp
@@ -39,7 +39,7 @@
  *  Testbench for the sliding window generator HLS block for 1D convolutions
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 4096
+#define AP_INT_MAX_W 8191
 #include <hls_stream.h>
 #include "ap_int.h"
 #include <iostream>

--- a/tb/swg_1D_tb.cpp
+++ b/tb/swg_1D_tb.cpp
@@ -40,7 +40,7 @@
  *  Testbench for the sliding window generator HLS block for 1D convolutions
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 4096
+#define AP_INT_MAX_W 8191
 #include <hls_stream.h>
 #include "ap_int.h"
 #include <iostream>

--- a/tb/test_conv3_inj_stmr.tcl
+++ b/tb/test_conv3_inj_stmr.tcl
@@ -40,8 +40,8 @@
  #
 ###############################################################################
 open_project hls-syn-conv-inj-stmr
-add_files conv_stmr_inj_top.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
-add_files -tb conv3_stmr_inj_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+add_files conv_stmr_inj_top.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+add_files -tb conv3_stmr_inj_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
 set_top Testbench_conv_inj_stmr
 open_solution sol1
 set_part {xczu3eg-sbva484-1-i}

--- a/tb/test_conv3_noinj_stmr.tcl
+++ b/tb/test_conv3_noinj_stmr.tcl
@@ -40,8 +40,8 @@
  #
 ###############################################################################
 open_project hls-syn-conv-noinj-stmr
-add_files conv_stmr_noinj_top.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
-add_files -tb conv3_stmr_noinj_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+add_files conv_stmr_noinj_top.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+add_files -tb conv3_stmr_noinj_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
 set_top Testbench_conv_noinj_stmr
 open_solution sol1
 set_part {xczu3eg-sbva484-1-i}

--- a/tb/test_dup_stream.tcl
+++ b/tb/test_dup_stream.tcl
@@ -1,3 +1,44 @@
+##############################################################################
+ #  Copyright (c) 2019, Xilinx, Inc.
+ #  Copyright (c) 2022, Advanced Micro Devices, Inc.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions are met:
+ #
+ #  1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ #  2.  Redistributions in binary form must reproduce the above copyright
+ #      notice, this list of conditions and the following disclaimer in the
+ #      documentation and/or other materials provided with the distribution.
+ #
+ #  3.  Neither the name of the copyright holder nor the names of its
+ #      contributors may be used to endorse or promote products derived from
+ #      this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ #  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ #  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ #  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ #  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ #  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+###############################################################################
+###############################################################################
+ #
+ #  Authors: Giulio Gambardella <giuliog@xilinx.com>
+ #
+ # \file test_dup_stream.tcl
+ #
+ # Tcl script for HLS csim, synthesis and cosim of the duplicate stream layer
+ #
+###############################################################################
 open_project hls-syn-dup_stream
 add_files dup_stream_top.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
 add_files -tb dup_stream_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 

--- a/tb/test_pool.tcl
+++ b/tb/test_pool.tcl
@@ -34,7 +34,7 @@
  #
  #  Authors: Giulio Gambardella <giuliog@xilinx.com>
  #
- # \file test-pool.tcl
+ # \file test_pool.tcl
  #
  # Tcl script for HLS csim, synthesis and cosim of the max pooling layer
  #

--- a/tb/test_qdma_stream.tcl
+++ b/tb/test_qdma_stream.tcl
@@ -1,3 +1,44 @@
+##############################################################################
+ #  Copyright (c) 2019, Xilinx, Inc.
+ #  Copyright (c) 2022, Advanced Micro Devices, Inc.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions are met:
+ #
+ #  1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ #  2.  Redistributions in binary form must reproduce the above copyright
+ #      notice, this list of conditions and the following disclaimer in the
+ #      documentation and/or other materials provided with the distribution.
+ #
+ #  3.  Neither the name of the copyright holder nor the names of its
+ #      contributors may be used to endorse or promote products derived from
+ #      this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ #  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ #  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ #  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ #  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ #  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+###############################################################################
+###############################################################################
+ #
+ #  Authors: Lucian Petrica <lucianp@xilinx.com>
+ #
+ # \file test_qdma_stream.tcl
+ #
+ # Tcl script for HLS csim, synthesis and cosim of the qdma stream layer
+ #
+###############################################################################
 open_project hls-syn-qdma
 add_files qdma_stream_top.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
 add_files -tb qdma_stream_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 

--- a/tb/test_swg_1D_dws.tcl
+++ b/tb/test_swg_1D_dws.tcl
@@ -32,16 +32,16 @@
 ###############################################################################
 ###############################################################################
  #
- #  Authors: Mirza Mrahorovic <mirzamg@xilinx.com>
+ #  Authors: Mirza Mrahorovic <mirzam@xilinx.com>
  #
  # \file test_swg_1D_dws.tcl
  #
- # Tcl script for HLS csim, synthesis and cosim of the sliding window generator block for 1D convolutions
+ # Tcl script for HLS csim, synthesis and cosim of the sliding window generator block for 1D depthwise separable convolutions
  #
 ###############################################################################
-open_project hls-syn-swg-1d
-add_files input_gen_1D_dws.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)" 
-add_files -tb swg_1D_dws_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)" 
+open_project hls-syn-swg-1d-dws
+add_files input_gen_1D_dws.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)"
+add_files -tb swg_1D_dws_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)"
 set_top Testbench
 open_solution sol1
 set_part {xczu3eg-sbva484-1-i}

--- a/tb/test_swg_kernelstride_mmv.tcl
+++ b/tb/test_swg_kernelstride_mmv.tcl
@@ -34,15 +34,15 @@
  #
  #  Authors: Giulio Gambardella <giuliog@xilinx.com>
  #
- # \file test_swg_kernelstride.tcl
+ # \file test_swg_kernelstride_mmv.tcl
  #
  # Tcl script for HLS csim, synthesis and cosim of the sliding window generator block
  # when kernel%stride !=0
  #
 ###############################################################################
 open_project hls-syn-swg-ks-mmv
-add_files input_gen_kernelstride_mmv.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT)" 
-add_files -tb swg_kernelstride_mmv_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT)" 
+add_files input_gen_kernelstride_mmv.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)" 
+add_files -tb swg_kernelstride_mmv_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT)" 
 set_top Testbench
 open_solution sol1
 set_part {xczu3eg-sbva484-1-i}

--- a/tb/test_tmrc_stmr.tcl
+++ b/tb/test_tmrc_stmr.tcl
@@ -40,8 +40,8 @@
  #
 ###############################################################################
 open_project hls-syn-tmrc-stmr
-add_files tmrc_stmr_top.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
-add_files -tb tmrc_stmr_tb.cpp -cflags "-std=c++0x -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+add_files tmrc_stmr_top.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
+add_files -tb tmrc_stmr_tb.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb" 
 set_top Testbench_tmrc_stmr
 open_solution sol1
 set_part {xczu3eg-sbva484-1-i}

--- a/tb/test_upsample.tcl
+++ b/tb/test_upsample.tcl
@@ -1,3 +1,44 @@
+##############################################################################
+ #  Copyright (c) 2021, Xilinx, Inc.
+ #  Copyright (c) 2022, Advanced Micro Devices, Inc.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions are met:
+ #
+ #  1.  Redistributions of source code must retain the above copyright notice,
+ #     this list of conditions and the following disclaimer.
+ #
+ #  2.  Redistributions in binary form must reproduce the above copyright
+ #      notice, this list of conditions and the following disclaimer in the
+ #      documentation and/or other materials provided with the distribution.
+ #
+ #  3.  Neither the name of the copyright holder nor the names of its
+ #      contributors may be used to endorse or promote products derived from
+ #      this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ #  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ #  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ #  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ #  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ #  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ #  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+###############################################################################
+###############################################################################
+ #
+ #  Authors: Giulio Gambardella <giuliog@xilinx.com>
+ #
+ # \file test_upsample.tcl
+ #
+ # Tcl script for HLS csim, synthesis and cosim of upsample
+ #
+###############################################################################
 delete_project hls-syn-upsample
 open_project hls-syn-upsample
 add_files upsample_top.cpp -cflags "-std=c++14 -I$::env(FINN_HLS_ROOT) -I$::env(FINN_HLS_ROOT)/tb"

--- a/tb/tmrc_stmr_tb.cpp
+++ b/tb/tmrc_stmr_tb.cpp
@@ -39,7 +39,7 @@
  *  Testbench for the HLS block which performs redundancy checks
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #define INJ false
 #include <iostream>
 #include <fstream>

--- a/tb/tmrc_stmr_top.cpp
+++ b/tb/tmrc_stmr_top.cpp
@@ -39,7 +39,7 @@
  *  HLS Top function with a single tmrc layer for unit testing
  *
  *****************************************************************************/
-#define AP_INT_MAX_W 16384
+#define AP_INT_MAX_W 8191
 #include <hls_stream.h>
 using namespace hls;
 #include "ap_int.h"


### PR DESCRIPTION
## Bug fix
- `memory_resource` is not inlined anymore. Pragmas in inlined functions seem to get ignored: see description here https://docs.xilinx.com/r/en-US/ug1399-vitis-hls/pragma-HLS-inline. 

## Others
- Added AMD copyright, appended authors/file tags, changed cflags (c++14)
- Changed project directory (to a unique one) for particular tcl script to pass Jenkins test
- Set maximum stream width constant to 8191