### PR TITLE
Fix to ConvolutionInputGenerator_kernel1

### DIFF
--- a/slidingwindow.h
+++ b/slidingwindow.h
@@ -1186,17 +1186,19 @@ void ConvolutionInputGenerator_kernel1(
 static_assert(IFMChannels % SIMD == 0, "");
 constexpr unsigned COUNTER_WIDTH = clog2(Stride-1) + 1;
 constexpr unsigned COUNTER_RESET = Stride - 2;
+constexpr unsigned MULTIPLYING_FACTOR = IFMChannels/SIMD;
 	for (unsigned int im=0; im<numReps; im++) {
+#pragma HLS performance target_ti=IFMDim*IFMDim*IFMChannels/SIMD
 		ap_int<COUNTER_WIDTH> counter_y = -1;
 		for (unsigned int y = 0; y < IFMDim; y++) {
 			const bool keep_y = counter_y < 0;
 			counter_y = keep_y ? ap_int<COUNTER_WIDTH>(COUNTER_RESET) : ap_int<COUNTER_WIDTH>(counter_y - 1);
 			ap_int<COUNTER_WIDTH> counter_x = -1;
 			for (unsigned int x = 0; x < IFMDim; x++) {
+#pragma HLS pipeline style=flp II=IFMChannels/SIMD
 				const bool keep_x = counter_x < 0;
 				counter_x = keep_x ? ap_int<COUNTER_WIDTH>(COUNTER_RESET) : ap_int<COUNTER_WIDTH>(counter_x - 1);
-				for (unsigned int count_simd = 0; count_simd < IFMChannels/SIMD; count_simd++) {
-#pragma HLS pipeline style=flp II=1
+				for (unsigned int count_simd = 0; count_simd < MULTIPLYING_FACTOR; count_simd++) {
 					ap_uint<SIMD*Input_precision> inElem = in.read();
 					if (keep_y && keep_x) {
 						out.write(inElem);


### PR DESCRIPTION
- Vitis HLS generated either non-flushing or flushing pipeline depending on which board is targeted.
- Solution (proposed by @preusser) resolves this problem by adding 'performance' pragma and placing the 'pipeline' pragma out of the innermost loop.
- Tested new function in isolation (RTL simulation) & through FINN's [test case](https://github.com/Xilinx/finn/blob/96c0f5e3678abd7b1eaab2a2b4f8e937ac1f48b8/tests/fpgadataflow/test_convert_to_hls_conv_layer.py#L64) for DownSampler custom-op.