### PR TITLE
Add node label to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@
  *
  ******************************************************************************/
 
-node {
+node('finn-build || built-in') {
     def app
     stage('Clone repository') {
         /* Let's make sure we have the repository cloned to our workspace */


### PR DESCRIPTION
We are pulling this job into our Jenkins but need it to run on a certain host. I have added some labels to the test node. If there are machines available with the label "finn-build", the job will run on one of them. Otherwise, the job will fall back to "built-in" which is the default node name. This change should have no impact on any existing deployments. 