### PR TITLE
Add float support to Slice by specializing Width and Caster template

### DIFF
--- a/interpret.hpp
+++ b/interpret.hpp
@@ -187,9 +187,23 @@ struct Caster<ap_fixed<W, I, Q, O, N>> {
   static ap_fixed<W, I, Q, O, N> cast(ap_int<M> const &arg) {
     return  ap_fixed<W, I, Q, O, N>(arg);
   }
-}; 
+};
 
-template<typename T, unsigned STRIDE=T::width>
+template<>
+struct Caster<float> {
+	template<int M>
+	static float cast(ap_int<M> const &arg) {
+	 return *reinterpret_cast<const float*>(&arg);
+	}
+};
+
+template<class Type>
+    constexpr auto Width = Type::width;
+
+template<>
+    constexpr auto Width<float> = 32;
+
+template<typename T, unsigned STRIDE = Width<T>>
 class Slice {
  public:
   static unsigned const  width = STRIDE;
@@ -246,7 +260,7 @@ class Slice {
 
 
 // This class is done for Slicing an MMV container (vector of ap_uint)
-template<typename T, unsigned MMV, unsigned STRIDE=T::width>
+template<typename T, unsigned MMV, unsigned STRIDE = Width<T>>
 class Slice_mmv {
  public:
   static unsigned const  width = STRIDE;

--- a/interpret.hpp
+++ b/interpret.hpp
@@ -192,9 +192,7 @@ struct Caster<ap_fixed<W, I, Q, O, N>> {
 
 template<>
 struct Caster<float> {
-	template<int M>
-	static float cast(ap_int<M> const &arg) {
-		static_assert(M == 32, "Can only reinterpret 32-bit values as floats.");
+	static float cast(ap_int<32> const &arg) {
 		union { int32_t  i; float  f; } const  conv = { .i = arg };
 		return  conv.f;
 	}


### PR DESCRIPTION
This is required for implementing floating-point support for generic element-wise binary operations in FINN, proposed here: https://github.com/Xilinx/finn/pull/1040

This does not change the behavior of `Slice`  for already supported types, it just adds template a specialization of `Caster` for float via `reinterpret_cast` and proposes a new mechanism of setting the default `STRIDE` avoiding `T::width` which doe not exist for floats.