### PR TITLE
feature/instrumentation: additions and fixes from stac demo

### DIFF
--- a/instrumentation_wrapper.cpp
+++ b/instrumentation_wrapper.cpp
@@ -257,8 +257,7 @@ void instrument(
 	cnt_clk++;
 
 	// Copy Status Outputs
-	status[0] = timestamp_ovf;
-	status[1] = timestamp_unf;
+	status = timestamp_ovf | (timestamp_unf << 1);
 	latency  = last_latency;
 	interval = last_interval;
 	checksum = last_checksum;


### PR DESCRIPTION
This PR adds two changes:
1. Ensure status register at 0x18 reports the underflow/overflow flags correctly.
2. Add a minimum latency register.

See commit messages for justifications.

Note that change 1 above may change the clear semantics of the status register. I believe that previously it was possible to clear the status from the host/PS by writing 0 to it, whereas now that register is read-only. It should still be cleared on reset AFAIK.

Also note that the status flag values persist across multiple measurements. This behaviour is unchanged from before this PR.