### PR TITLE
[Deconv] Changing the parallelisation parameter of MVU's output stream so that it matches the template.

### DIFF
--- a/deconv.hpp
+++ b/deconv.hpp
@@ -449,7 +449,7 @@ void deconv(
 	// Activation Processing Pipeline: pad -> swg -> mvu -> crop
 	static hls::stream<hls::vector<TI, SIMD>>  src_eff("src_eff");
 	static hls::stream<hls::vector<TI, SIMD>>  swg    ("swg");
-	static hls::stream<hls::vector<TO, SIMD>>  dst_eff("dst_eff");
+	static hls::stream<hls::vector<TO, PE>>  dst_eff("dst_eff");
 #pragma HLS stream depth=2 variable=src_eff
 #pragma HLS stream depth=2 variable=swg
 #pragma HLS stream depth=2 variable=dst_eff


### PR DESCRIPTION
This was creating an error when trying to use a SIMD or PE values that are greater than 1.
The MVU's output stream was set to be of <TO, SIMD> shape, when it should be <TO, PE>, as PE is what dictates the output parallelism. This is also what the template expects.
