### PR TITLE
Add flatten utils and specializations for half dtype

### DIFF
--- a/activations.hpp
+++ b/activations.hpp
@@ -340,7 +340,7 @@ template <
     typename TI, typename TO>
 void Thresholding_Stream_Batch(hls::stream<TI> &in,
                         hls::stream<TO> &out,
-                        hls::stream<ap_uint<PE*NumSteps*TT::width>> &weight,
+                        hls::stream<ap_uint<PE*NumSteps*width_v<TT>>> &weight,
                         int const reps)
 {
 
@@ -357,10 +357,10 @@ void Thresholding_Stream_Batch(hls::stream<TI> &in,
   {
 #pragma HLS pipeline style=flp II=1
 
-    ap_uint<PE*NumSteps*TT::width> packed_thr;
+    ap_uint<PE*NumSteps*width_v<TT>> packed_thr;
     packed_thr = weight.read();
     // slicer to get 1 PE's worth of thresholds
-    auto const pe_slicer = Slice<ap_uint<NumSteps*TT::width>>()(packed_thr);
+    auto const pe_slicer = Slice<ap_uint<NumSteps*width_v<TT>>>()(packed_thr);
 
     TI inElem;
     inElem = in.read();

--- a/flatten.hpp
+++ b/flatten.hpp
@@ -1,0 +1,107 @@
+/******************************************************************************
+ *  Copyright (c) 2024, Christoph Berganski
+ *  Copyright (c) 2024, Advanced Micro Devices, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *******************************************************************************/
+
+#ifndef FLATTEN_HPP
+#define FLATTEN_HPP
+
+// HLS arbitrary precision types
+#include <ap_int.h>
+
+static ap_int<32> float2apint_cast(float const &arg) {
+    union { int32_t  i; float  f; } const  conv = { .f = arg };
+    return  (ap_int<32> )conv.i;
+}
+
+static ap_int<16> half2apint_cast(half const &arg) {
+    union { int16_t  i; half  h; } const  conv = { .h = arg };
+    return  (ap_int<16> )conv.i;
+}
+
+// Flattens an array of N elements of Type into a single bitvector
+template<long unsigned N, class Type>
+    ap_uint<N * Type::width> flatten(const Type buffer[N]) {
+// Inline this small piece of bit merging logic
+#pragma HLS INLINE
+        // Fill a flat word of N times the bit-width of the element type
+        ap_uint<N * Type::width> flat;
+        // Merge all N chunks of the tile into the flat bitvector
+        for(unsigned j = 0; j < N; ++j) {
+// Do the merging of all chunks in parallel
+#pragma HLS UNROLL
+            // Insert the chunk into the right place of the
+            // bitvector
+            flat((j + 1) * Type::width - 1, j * Type::width) = buffer[j];
+        }
+        // Return the buffer flattened into a single bitvector
+        return flat;
+    }
+
+// Flattens an array of N elements of float into a single bitvector
+template<long unsigned N>
+    ap_uint<N * 32> flatten(const float buffer[N]) {
+// Inline this small piece of bit merging logic
+#pragma HLS INLINE
+        // Fill a flat word of N times the bit-width of the element type
+        ap_uint<N * 32> flat;
+        // Merge all N chunks of the tile into the flat bitvector
+        for(unsigned j = 0; j < N; ++j) {
+// Do the merging of all chunks in parallel
+#pragma HLS UNROLL
+            // Insert the chunk into the right place of the
+            // bitvector
+            flat((j + 1) * 32 - 1, j * 32) = float2apint_cast(buffer[j]);
+        }
+        // Return the buffer flattened into a single bitvector
+        return flat;
+    }
+
+// Flattens an array of N elements of half into a single bitvector
+template<long unsigned N>
+    ap_uint<N * 16> flatten(const half buffer[N]) {
+// Inline this small piece of bit merging logic
+#pragma HLS INLINE
+        // Fill a flat word of N times the bit-width of the element type
+        ap_uint<N * 16> flat;
+        // Merge all N chunks of the tile into the flat bitvector
+        for(unsigned j = 0; j < N; ++j) {
+// Do the merging of all chunks in parallel
+#pragma HLS UNROLL
+            // Insert the chunk into the right place of the
+            // bitvector
+            flat((j + 1) * 16 - 1, j * 16) = half2apint_cast(buffer[j]);
+        }
+        // Return the buffer flattened into a single bitvector
+        return flat;
+    }
+
+#endif // FLATTEN_HPP

--- a/flatten.hpp
+++ b/flatten.hpp
@@ -36,6 +36,8 @@
 
 // HLS arbitrary precision types
 #include <ap_int.h>
+// width_v (since ::width doesn't work for float, half..)
+#include "interpret.hpp"
 
 static ap_int<32> float2apint_cast(float const &arg) {
     union { int32_t  i; float  f; } const  conv = { .f = arg };
@@ -49,18 +51,18 @@ static ap_int<16> half2apint_cast(half const &arg) {
 
 // Flattens an array of N elements of Type into a single bitvector
 template<long unsigned N, class Type>
-    ap_uint<N * Type::width> flatten(const Type buffer[N]) {
+    ap_uint<N * width_v<Type>> flatten(const Type buffer[N]) {
 // Inline this small piece of bit merging logic
 #pragma HLS INLINE
         // Fill a flat word of N times the bit-width of the element type
-        ap_uint<N * Type::width> flat;
+        ap_uint<N * width_v<Type>> flat;
         // Merge all N chunks of the tile into the flat bitvector
         for(unsigned j = 0; j < N; ++j) {
 // Do the merging of all chunks in parallel
 #pragma HLS UNROLL
             // Insert the chunk into the right place of the
             // bitvector
-            flat((j + 1) * Type::width - 1, j * Type::width) = buffer[j];
+            flat((j + 1) * width_v<Type> - 1, j * width_v<Type>) = buffer[j];
         }
         // Return the buffer flattened into a single bitvector
         return flat;

--- a/flatten.hpp
+++ b/flatten.hpp
@@ -57,6 +57,13 @@ ap_uint<32> bit_image(float const &val) {
 }
 
 template<>
+ap_uint<64> bit_image(double const &val) {
+#pragma HLS inline
+	union { uint64_t  i; double  f; } const  conv = { .f = val };
+	return  ap_uint<64>(conv.i);
+}
+
+template<>
 ap_uint<16> bit_image(half const &val) {
 #pragma HLS inline
 	union { uint16_t  i; half  f; } const  conv = { .f = val };

--- a/interpret.hpp
+++ b/interpret.hpp
@@ -50,6 +50,7 @@
 
 #include <ap_int.h>
 #include <cstdint>
+#include <cstddef>
 #include <ostream>
 
 /**
@@ -207,11 +208,11 @@ struct Caster<half> {
 };
 
 template<typename  T>
-constexpr auto  width_v = T::width;
-template<>
-constexpr auto  width_v<float> = 32;
-template<>
-constexpr auto  width_v<half> = 16;
+constexpr size_t  width_v = 8*sizeof(T);
+template<size_t  N>
+constexpr size_t  width_v<ap_int<N>> = N;
+template<size_t  N>
+constexpr size_t  width_v<ap_uint<N>> = N;
 
 template<typename T, unsigned STRIDE = width_v<T>>
 class Slice {

--- a/interpret.hpp
+++ b/interpret.hpp
@@ -198,10 +198,20 @@ struct Caster<float> {
 	}
 };
 
+template<>
+struct Caster<half> {
+	static half cast(ap_int<16> const &arg) {
+		union { int16_t  i; half h; } const  conv = { .i = int16_t(arg) };
+		return  conv.h;
+	}
+};
+
 template<typename  T>
 constexpr auto  width_v = T::width;
 template<>
 constexpr auto  width_v<float> = 32;
+template<>
+constexpr auto  width_v<half> = 16;
 
 template<typename T, unsigned STRIDE = width_v<T>>
 class Slice {

--- a/interpret.hpp
+++ b/interpret.hpp
@@ -209,9 +209,9 @@ struct Caster<half> {
 
 template<typename  T>
 constexpr size_t  width_v = 8*sizeof(T);
-template<size_t  N>
+template<int  N>
 constexpr size_t  width_v<ap_int<N>> = N;
-template<size_t  N>
+template<int  N>
 constexpr size_t  width_v<ap_uint<N>> = N;
 
 template<typename T, unsigned STRIDE = width_v<T>>

--- a/interpret.hpp
+++ b/interpret.hpp
@@ -207,12 +207,11 @@ struct Caster<half> {
 	}
 };
 
-template<typename  T>
-constexpr size_t  width_v = 8*sizeof(T);
-template<int  N>
-constexpr size_t  width_v<ap_int<N>> = N;
-template<int  N>
-constexpr size_t  width_v<ap_uint<N>> = N;
+// Determine bit width of types
+template<typename  T> std::integral_constant<size_t, 8*sizeof(T)> get_width_v(...);    // standard types
+template<typename  T> std::integral_constant<size_t, T::width>    get_width_v(void*);  // types with explicit T::width
+template<typename  T> constexpr size_t  width_v = decltype(get_width_v<T>(nullptr))::value;
+
 
 template<typename T, unsigned STRIDE = width_v<T>>
 class Slice {

--- a/tb/flatten_tb.cpp
+++ b/tb/flatten_tb.cpp
@@ -8,21 +8,29 @@
  ****************************************************************************/
 
 // g++ -Wall -Wno-unknown-pragmas -O2 -DHLS_NO_XIL_FPO_LIB
-#include <iostream>
-#include <cmath>
 #include "flatten.hpp"
+
+#include <iostream>
+#include "ap_float.h"
 
 
 int main() {
+	static_assert(width_v<short> == 16, "Wrong bitwidth for short.");
+	static_assert(width_v<ap_int<3>> == 3, "Wrong bitwidth for ap_int.");
+	static_assert(width_v<ap_fixed< 6, 3>> == 6, "Wrong bitwidth for ap_fixed.");
+	static_assert(width_v<ap_float<12, 5>> == 12, "Wrong bitwidth for ap_float.");
+
 	float const  a1[] = {  0.0f,  1.0f,  2.0f, 0.0f/0.0f };
 	half  const  a2[] = { -0.0f, -1.0f, -2.0f, 1.0f/0.0f };
 	char  const  a3[] = "abcdefg";
-	hls::vector<ap_uint<4>, 6> const  v1 = { 2, 3, 5, 7, 11, 13 };
+	hls::vector<ap_uint<4>,     6> const  v1 = { 2, 3, 5, 7, 11, 13 };
+	hls::vector<ap_fixed<4, 2>, 6> const  v2 = { 0.5, .75, 1.25, 1.75, 2.75, 3.25 };
 
 	std::cout << std::hex
 		<< flatten(a1) << std::endl
 		<< flatten(a2) << std::endl
 		<< flatten(a3) << std::endl
-		<< flatten(v1) << std::endl;
+		<< flatten(v1) << std::endl
+		<< flatten(v2) << std::endl;
 
 }

--- a/tb/flatten_tb.cpp
+++ b/tb/flatten_tb.cpp
@@ -1,0 +1,28 @@
+/****************************************************************************
+ * Copyright (C) 2024, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * @author	Thomas B. Preußer <thomas.preusser@amd.com>
+ ****************************************************************************/
+
+// g++ -Wall -Wno-unknown-pragmas -O2 -DHLS_NO_XIL_FPO_LIB
+#include <iostream>
+#include <cmath>
+#include "flatten.hpp"
+
+
+int main() {
+	float const  a1[] = {  0.0f,  1.0f,  2.0f, 0.0f/0.0f };
+	half  const  a2[] = { -0.0f, -1.0f, -2.0f, 1.0f/0.0f };
+	char  const  a3[] = "abcdefg";
+	hls::vector<ap_uint<4>, 6> const  v1 = { 2, 3, 5, 7, 11, 13 };
+
+	std::cout << std::hex
+		<< flatten(a1) << std::endl
+		<< flatten(a2) << std::endl
+		<< flatten(a3) << std::endl
+		<< flatten(v1) << std::endl;
+
+}


### PR DESCRIPTION
Add flatten.hpp to finn-hlslib, originally introduced by @iksnagreb in this PR in the FINN custom HLS directory: https://github.com/Xilinx/finn/pull/1040

Also add template specializations of `width_v` and `Caster` for the `half` dtype (float16), and use `width_v` instead of `::width` in `activations.hpp`.