### PR TITLE
Fix the Utils Include in crop.hpp

### DIFF
--- a/crop.hpp
+++ b/crop.hpp
@@ -9,7 +9,7 @@
 #ifndef CROP_HPP
 #define CROP_HPP
 
-#include "util.hpp"
+#include "utils.hpp"
 #include <hls_stream.h>
 #include <ap_int.h>
 


### PR DESCRIPTION
I believe the util.hpp include should refer to utils.hpp. Otherwise, it is unable to include the file.  