### PR TITLE
Fix slicing into ap_(u)fixed<> types

### DIFF
--- a/interpret.hpp
+++ b/interpret.hpp
@@ -187,9 +187,13 @@ template<int W, int I, ap_q_mode Q, ap_o_mode O, int N>
 struct Caster<ap_fixed<W, I, Q, O, N>> {
   template<int M>
   static ap_fixed<W, I, Q, O, N> cast(ap_int<M> const &arg) {
-    return  ap_fixed<W, I, Q, O, N>(arg);
+    union { ap_int<M>  int_type; ap_fixed<W, I, Q, O, N>  fixed_type; } const  conv = { .int_type = arg };
+    return  conv.fixed_type;
   }
 };
+
+
+
 
 template<>
 struct Caster<float> {

--- a/interpret.hpp
+++ b/interpret.hpp
@@ -185,15 +185,21 @@ struct Caster {
 
 template<int W, int I, ap_q_mode Q, ap_o_mode O, int N>
 struct Caster<ap_fixed<W, I, Q, O, N>> {
-  template<int M>
-  static ap_fixed<W, I, Q, O, N> cast(ap_int<M> const &arg) {
-    union { ap_int<M>  int_type; ap_fixed<W, I, Q, O, N>  fixed_type; } const  conv = { .int_type = arg };
-    return  conv.fixed_type;
+  static ap_fixed<W, I, Q, O, N> cast(ap_int<W> const &arg) {
+    ap_fixed<W, I, Q, O, N>  res;
+    res(W-1, 0) = arg;
+    return  res;
   }
 };
 
-
-
+template<int W, int I, ap_q_mode Q, ap_o_mode O, int N>
+struct Caster<ap_ufixed<W, I, Q, O, N>> {
+  static ap_ufixed<W, I, Q, O, N> cast(ap_int<W> const &arg) {
+    ap_ufixed<W, I, Q, O, N>  res;
+    res(W-1, 0) = arg;
+    return  res;
+  }
+};
 
 template<>
 struct Caster<float> {


### PR DESCRIPTION
Quick fix to correctly apply `Caster` and `Slice` for `ap_fixed` types, using the same union-based approach for floats. The previous direct-casting was yielding incorrect results.